### PR TITLE
feat: Apply rules only to classes that extends Construct

### DIFF
--- a/docs/ja/rules/no-construct-stack-suffix.md
+++ b/docs/ja/rules/no-construct-stack-suffix.md
@@ -10,13 +10,17 @@ titleTemplate: ":title"
   を使用した場合、このルールが有効になります。
 </div>
 
-このルールは、コンストラクト ID およびスタック ID で `Construct` または `Stack` サフィックスの使用を禁止するものです。
+このルールは、コンストラクト ID およびスタック ID で `Construct` または `Stack` サフィックスの使用を禁止するものです。  
+(このルールは `Construct` または `Stack` を継承したクラスにのみ適用されます)
 
 コンストラクト ID に `Construct` が含まれていると、CDK の世界で止めるべき問題が CloudFormation テンプレートおよび AWS の世界に漏れてしまうため、好ましくありません。(スタック ID についても同様です)
 
 #### ✅ 正しい例
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -28,6 +32,9 @@ export class MyConstruct extends Construct {
 #### ❌ 不正な例
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);

--- a/docs/ja/rules/no-mutable-props-interface.md
+++ b/docs/ja/rules/no-mutable-props-interface.md
@@ -25,6 +25,8 @@ Props で変更可能なパブリック変数を指定すると、意図しな�
 #### ✅ 正しい例
 
 ```ts
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 interface MyConstructProps {
   readonly bucket: IBucket;
 }
@@ -33,6 +35,8 @@ interface MyConstructProps {
 #### ❌ 誤った例
 
 ```ts
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 interface MyConstructProps {
   bucket: IBucket;
 }

--- a/docs/ja/rules/no-mutable-public-fields.md
+++ b/docs/ja/rules/no-mutable-public-fields.md
@@ -17,14 +17,17 @@ titleTemplate: ":title"
   で自動修正できます。
 </div>
 
-このルールは、クラスのパブリック変数を変更可能にすることを禁止するものです。  
-(`readonly`でないパブリック変数の定義を禁止します)
+このルールは、クラスのパブリック変数を変更可能にすること(`readonly`でないパブリック変数の定義)を禁止するものです。  
+(このルールは `Construct` または `Stack` を継承したクラスにのみ適用されます)
 
 パブリック変数が変更可能である場合、意図しない副作用が発生する可能性があるため、推奨されません。
 
 #### ✅ 正しい例
 
 ```ts
+import { Construct } from "constructs";
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   public readonly bucket: IBucket;
 }
@@ -33,6 +36,9 @@ export class MyConstruct extends Construct {
 #### ❌ 不正な例
 
 ```ts
+import { Construct } from "constructs";
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   public bucket: IBucket;
 }

--- a/docs/ja/rules/no-parent-name-construct-id-match.md
+++ b/docs/ja/rules/no-parent-name-construct-id-match.md
@@ -17,6 +17,9 @@ titleTemplate: ":title"
 #### ✅ 正しい例
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -28,6 +31,9 @@ export class MyConstruct extends Construct {
 #### ❌ 不正な例
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);

--- a/docs/ja/rules/no-public-class-fields.md
+++ b/docs/ja/rules/no-public-class-fields.md
@@ -10,14 +10,16 @@ titleTemplate: ":title"
   を使用した場合、このルールが有効になります。
 </div>
 
-このルールは、クラスの`public`変数にクラスを使用することを禁止します。
+このルールは、クラスの`public`変数にクラスを使用することを禁止します。  
+(このルールは `Construct` または `Stack` を継承したクラスにのみ適用されます)
 
 `public`変数でクラス型を使用すると、密結合が作成され、可変状態が公開されるため、推奨されません。
 
 #### ✅ 正しい例
 
 ```ts
-import { IBucket } from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+import { IBucket, Bucket } from "aws-cdk-lib/aws-s3";
 
 class MyConstruct extends Construct {
   public readonly bucket: IBucket;
@@ -31,6 +33,7 @@ class MyConstruct extends Construct {
 #### ❌ 不正な例
 
 ```ts
+import { Construct } from "constructs";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 
 class MyConstruct extends Construct {

--- a/docs/ja/rules/pascal-case-construct-id.md
+++ b/docs/ja/rules/pascal-case-construct-id.md
@@ -17,16 +17,21 @@ titleTemplate: ":title"
   で自動修正できます。
 </div>
 
-このルールは、コンストラクト ID に PascalCase を強制します。
+このルールは、コンストラクト ID に PascalCase を強制します。  
+(このルールは `Construct` または `Stack` を継承したクラスにのみ適用されます)
 
 #### ✅ 正しい例
 
 ```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 const bucket = new Bucket(this, "MyBucket");
 ```
 
 #### ❌ 不正な例
 
 ```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 const bucket = new Bucket(this, "myBucket");
 ```

--- a/docs/rules/no-construct-stack-suffix.md
+++ b/docs/rules/no-construct-stack-suffix.md
@@ -11,13 +11,17 @@ titleTemplate: ":title"
   in an ESLint configuration enables this rule.
 </div>
 
-This rule is to disallow using the `Construct` or `Stack` suffix in construct IDs and stack IDs.
+This rule is to disallow using the `Construct` or `Stack` suffix in construct IDs and stack IDs.  
+(This rule applies only to classes that extends from `Construct` or `Stack`.)
 
 If the Construct ID includes "Construct," the issues that should be stopped in the CDK world will leak into the CloudFormation template and the AWS world, so not good.(the same for Stack ID )
 
 #### ✅ Correct Example
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -29,6 +33,9 @@ export class MyConstruct extends Construct {
 #### ❌ Incorrect Example
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);

--- a/docs/rules/no-mutable-props-interface.md
+++ b/docs/rules/no-mutable-props-interface.md
@@ -24,6 +24,8 @@ It is not a good to specify mutable public properties in props, as this can lead
 #### ✅ Correct Example
 
 ```ts
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 interface MyConstructProps {
   readonly bucket: IBucket;
 }
@@ -32,6 +34,8 @@ interface MyConstructProps {
 #### ❌ Incorrect Example
 
 ```ts
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 interface MyConstructProps {
   bucket: IBucket;
 }

--- a/docs/rules/no-mutable-public-fields.md
+++ b/docs/rules/no-mutable-public-fields.md
@@ -17,13 +17,17 @@ titleTemplate: ":title"
   </a>
 </div>
 
-This rule disallow making public variables of a class mutable.
+This rule disallow making public variables of a class mutable.  
+(This rule applies only to classes that extends from `Construct` or `Stack`.)
 
 It's not good to have mutable public variables, because it can lead to unintended side effects.
 
 #### ✅ Correct Example
 
 ```ts
+import { Construct } from "constructs";
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   public readonly bucket: IBucket;
 }
@@ -32,6 +36,9 @@ export class MyConstruct extends Construct {
 #### ❌ Incorrect Example
 
 ```ts
+import { Construct } from "constructs";
+import { IBucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   public bucket: IBucket;
 }

--- a/docs/rules/no-parent-name-construct-id-match.md
+++ b/docs/rules/no-parent-name-construct-id-match.md
@@ -18,6 +18,9 @@ It is not good to specify a string that matches the parent class name for constr
 #### ✅ Correct Example
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -29,6 +32,9 @@ export class MyConstruct extends Construct {
 #### ❌ Incorrect Example
 
 ```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);

--- a/docs/rules/no-public-class-fields.md
+++ b/docs/rules/no-public-class-fields.md
@@ -11,14 +11,16 @@ titleTemplate: ":title"
   in an ESLint configuration enables this rule.
 </div>
 
-This rule disallows using class types for public class fields.
+This rule disallows using class types for public class fields.  
+(This rule applies only to classes that extends from `Construct` or `Stack`.)
 
 When class types are used in public fields, it creates tight coupling and exposes mutable state, so not good.
 
 #### ✅ Correct Examples
 
 ```ts
-import { IBucket } from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+import { IBucket, Bucket } from "aws-cdk-lib/aws-s3";
 
 class MyConstruct extends Construct {
   public readonly bucket: IBucket;
@@ -32,6 +34,7 @@ class MyConstruct extends Construct {
 #### ❌ Incorrect Examples
 
 ```ts
+import { Construct } from "constructs";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 
 class MyConstruct extends Construct {

--- a/docs/rules/pascal-case-construct-id.md
+++ b/docs/rules/pascal-case-construct-id.md
@@ -18,16 +18,21 @@ titleTemplate: ":title"
   </a>
 </div>
 
-This rule enforces PascalCase for construct IDs.
+This rule enforces PascalCase for construct IDs.  
+(This rule applies only to classes that extends from `Construct` or `Stack`.)
 
 #### ✅ Correct Example
 
 ```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 const bucket = new Bucket(this, "MyBucket");
 ```
 
 #### ❌ Incorrect Example
 
 ```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
 const bucket = new Bucket(this, "myBucket");
 ```

--- a/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/src/__tests__/no-construct-stack-suffix.test.ts
@@ -14,255 +14,73 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
   valid: [
+    // WHEN: construct id has no suffix, and extends Construct
+    {
+      code: `
+      class TestConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new TestConstruct("test", "ValidId");
+      `,
+    },
+    // WHEN: construct id has no suffix, and extends Stack
+    {
+      code: `
+      class Stack {}
+      class TestStack extends Stack {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestStack("test", "ValidId");
+      `,
+    },
+    // WHEN: construct id has suffix, and not extends Construct or Stack
     {
       code: `
       class TestClass {
+        constructor(public id: string) {}
+      }
+      const test = new TestClass("test", "SampleConstruct");
+      `,
+    },
+    {
+      code: `
+      class TestClass {
+        constructor(public id: string) {}
+      }
+      class Sample {
         constructor() {
-          const test = new TestClass("test", "ValidId");
+          const test = new TestClass("test", "SampleConstruct");
         }
       }`,
     },
   ],
   invalid: [
-    /**
-     *
-     * WHEN: construct id has "Construct" suffix
-     *
-     */
+    // WHEN: construct id has "Construct" suffix, and extends Construct
     {
       code: `
-      export class TestClass {
-        constructor(public id: string) {
-          new SampleConstruct({ name: "sample" }, "SampleConstruct");
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
         }
-      }`,
+      }
+      new SampleConstruct({ name: "sample" }, "SampleConstruct");`,
       errors: [{ messageId: "noConstructStackSuffix" }],
     },
-    // variable declaration
+    // WHEN: stack id has "Stack" suffix, and extends Stack
     {
       code: `
-      export class TestClass {
-        constructor(public id: string) {
-          const test = new SampleConstruct({ name: "sample" }, "SampleConstruct");
+      class Stack {}
+      class SampleStack extends Stack {
+        constructor(props: any, id: string) {
+          super(props, id);
         }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // expression statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          if (true) new SampleConstruct("test", "SampleConstruct");
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // block statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          if (true) {
-            const test = new SampleConstruct("test", "SampleConstruct");
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // block statement / nested
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          if (true) {
-            if (true) {
-              const test = new SampleConstruct("test", "SampleConstruct");
-            }
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // switch statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          switch (item.type) {
-            case "test":
-              const test = new SampleConstruct("test", "SampleConstruct");
-              break;
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // switch statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          switch (item.type) {
-            case "test": {
-              const test = new SampleConstruct("test", "SampleConstruct");
-              break;
-            }
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // switch statement / nested
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          switch (item.type) {
-            case "test": {
-              switch (item.type) {
-                case "test":
-                  const test = new SampleConstruct("test", "SampleConstruct");
-                  break;
-              }
-            }
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // in method
-    {
-      code: `
-      export class TestClass {
-        constructor(public id: string) {
-          this.test();
-        }
-        test() {
-          new SampleConstruct({ name: "sample" }, "SampleConstruct");
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-
-    /**
-     *
-     * WHEN: stack id has "Stack" suffix
-     *
-     */
-    {
-      code: `
-      export class TestClass {
-        constructor(public id: string) {
-          new SampleStack({ name: "sample" }, "SampleStack");
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // variable declaration
-    {
-      code: `
-      export class TestClass {
-        constructor(public id: string) {
-          const test = new SampleStack({ name: "sample" }, "SampleStack");
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // expression statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          if (true) new SampleStack("test", "SampleStack");
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // block statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          if (true) {
-            const test = new SampleStack("test", "SampleStack");
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // block statement / nested
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          if (true) {
-            if (true) {
-              const test = new SampleStack("test", "SampleStack");
-            }
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // switch statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          switch (item.type) {
-            case "test":
-              const test = new SampleStack("test", "SampleStack");
-              break;
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // switch statement
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          switch (item.type) {
-            case "test": {
-              const test = new SampleStack("test", "SampleStack");
-              break;
-            }
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // switch statement / nested
-    {
-      code: `
-      class TestClass {
-        constructor() {
-          switch (item.type) {
-            case "test": {
-              switch (item.type) {
-                case "test":
-                  const test = new SampleStack("test", "SampleStack");
-                  break;
-              }
-            }
-          }
-        }
-      }`,
-      errors: [{ messageId: "noConstructStackSuffix" }],
-    },
-    // in method
-    {
-      code: `
-      export class TestClass {
-        constructor(public id: string) {
-          this.test();
-        }
-        test() {
-          new SampleStack({ name: "sample" }, "SampleStack");
-        }
-      }`,
+      }
+      new SampleStack({ name: "sample" }, "SampleStack");`,
       errors: [{ messageId: "noConstructStackSuffix" }],
     },
   ],

--- a/src/__tests__/no-mutable-public-fields.test.ts
+++ b/src/__tests__/no-mutable-public-fields.test.ts
@@ -56,35 +56,85 @@ ruleTester.run("no-mutable-public-fields", noMutablePublicFields, {
       }
       `,
     },
-  ],
-  invalid: [
-    // WHEN: public field is mutable
+    // WHEN: superClass is not Construct or Stack
     {
       code: `
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends DependencyClass {
+        public test: DependencyClass;
+      }
+      `,
+    },
+  ],
+  invalid: [
+    // WHEN: public field is mutable, nested superClass is Construct
+    {
+      code: `
+      class DependencyClass {}
+      class SampleConstruct extends Construct {}
+      class TestClass extends SampleConstruct {
         public test: DependencyClass;
       }
       `,
       errors: [{ messageId: "noMutablePublicFields" }],
       output: `
       class DependencyClass {}
-      class TestClass {
+      class SampleConstruct extends Construct {}
+      class TestClass extends SampleConstruct {
         public readonly test: DependencyClass;
       }
       `,
     },
+    // WHEN: public field is mutable, superClass is Construct
     {
       code: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
+        public test: DependencyClass;
+      }
+      `,
+      errors: [{ messageId: "noMutablePublicFields" }],
+      output: `
+      class Construct {}
+      class DependencyClass {}
+      class TestClass extends Construct {
+        public readonly test: DependencyClass;
+      }
+      `,
+    },
+    // WHEN: public field is mutable, superClass is Stack
+    {
+      code: `
+      class Stack {}
+      class DependencyClass {}
+      class TestClass extends Stack {
+        public test: DependencyClass;
+      }
+      `,
+      errors: [{ messageId: "noMutablePublicFields" }],
+      output: `
+      class Stack {}
+      class DependencyClass {}
+      class TestClass extends Stack {
+        public readonly test: DependencyClass;
+      }
+      `,
+    },
+    // WHEN: public field is mutable, `public` is omitted, superClass is Construct
+    {
+      code: `
+      class Construct {}
+      class DependencyClass {}
+      class TestClass extends Construct {
         test: DependencyClass;
       }
       `,
       errors: [{ messageId: "noMutablePublicFields" }],
       output: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
         readonly test: DependencyClass;
       }
       `,

--- a/src/__tests__/no-public-class-fields.test.ts
+++ b/src/__tests__/no-public-class-fields.test.ts
@@ -17,7 +17,8 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: field type is primitive
     {
       code: `
-      class TestClass {
+      class Construct {}
+      class TestClass extends Construct {
         public test: string;
       }
       `,
@@ -25,10 +26,11 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: field type is interface
     {
       code: `
+      class Construct {}
       interface ITest {
         value: string;
       }
-      class TestClass {
+      class TestClass extends Construct {
         public test: ITest;
       }
       `,
@@ -36,10 +38,11 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: field type is type alias
     {
       code: `
+      class Construct {}
       type TestType = {
         value: string;
       };
-      class TestClass {
+      class TestClass extends Construct {
         public test: TestType;
       }
       `,
@@ -47,8 +50,9 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: field is private
     {
       code: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
         private test: DependencyClass;
       }
       `,
@@ -56,7 +60,8 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: field has no type annotation
     {
       code: `
-      class TestClass {
+      class Construct {}
+      class TestClass extends Construct {
         public test;
       }
       `,
@@ -64,9 +69,19 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: field is protected
     {
       code: `
+      class Construct {}
+      class DependencyClass {}
+      class TestClass extends Construct {
+        protected test: DependencyClass;
+      }
+      `,
+    },
+    // WHEN: super class is not a construct
+    {
+      code: `
       class DependencyClass {}
       class TestClass {
-        protected test: DependencyClass;
+        public test: DependencyClass;
       }
       `,
     },
@@ -75,8 +90,9 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: public field uses class type
     {
       code: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
         public test: DependencyClass;
       }
       `,
@@ -85,8 +101,9 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: implicitly public field uses class type
     {
       code: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
         test: DependencyClass;
       }
       `,
@@ -95,8 +112,9 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: readonly public field uses class type
     {
       code: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
         public readonly test: DependencyClass;
       }
       `,
@@ -105,8 +123,9 @@ ruleTester.run("no-public-class-fields", noPublicClassFields, {
     // WHEN: constructor parameter property uses class type
     {
       code: `
+      class Construct {}
       class DependencyClass {}
-      class TestClass {
+      class TestClass extends Construct {
         constructor(public test: DependencyClass) {}
       }
       `,

--- a/src/__tests__/pascal-case-construct-id.test.ts
+++ b/src/__tests__/pascal-case-construct-id.test.ts
@@ -1,71 +1,125 @@
-import { RuleTester } from "eslint";
+import { RuleTester } from "@typescript-eslint/rule-tester";
 
 import { pascalCaseConstructId } from "../pascal-case-construct-id.mjs";
 
 const ruleTester = new RuleTester({
-  languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["*.ts*"],
+      },
+    },
+  },
 });
 
 ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
   valid: [
     // WHEN: id is empty
     {
-      code: "const test = new TestClass('test');",
-    },
-    {
-      code: "new TestClass('test');",
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test');
+      `,
     },
     // WHEN: id is object
     {
-      code: "const test = new TestClass('test', {sample: 'sample'});",
-    },
-    {
-      code: "new TestClass('test', {sample: 'sample'});",
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', {sample: 'sample'});`,
     },
     // WHEN: id is array
     {
-      code: "const test = new TestClass('test', ['sample']);",
-    },
-    {
-      code: "new TestClass('test', ['sample']);",
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', ['sample']);`,
     },
     // WHEN: id is number
     {
-      code: "const test = new TestClass('test', 1);",
-    },
-    {
-      code: "new TestClass('test', 1);",
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', 1);
+      `,
     },
     // WHEN: id is PascalCase
     {
-      code: "const test = new TestClass('test', 'ValidId');",
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', 'ValidId');`,
     },
+    // WHEN: not extends Construct
     {
-      code: "new TestClass('test', 'ValidId');",
+      code: `
+      class TestClass {
+        constructor(public id: string) {}
+      }
+      const test = new TestClass('test', 'ValidId');`,
     },
   ],
   invalid: [
     // WHEN: id is snake_case(double quote)
     {
-      code: 'new TestClass("test", "invalid_id");',
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass("test", "invalid_id");`,
       errors: [{ messageId: "pascalCaseConstructId" }],
-      output: 'new TestClass("test", "InvalidId");',
-    },
-    {
-      code: 'const test = new TestClass("test", "invalid_id");',
-      errors: [{ messageId: "pascalCaseConstructId" }],
-      output: 'const test = new TestClass("test", "InvalidId");',
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass("test", "InvalidId");`,
     },
     // WHEN: id is camelCase(single quote)
     {
-      code: "new TestClass('test', 'invalidId');",
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', 'invalidId');`,
       errors: [{ messageId: "pascalCaseConstructId" }],
-      output: "new TestClass('test', 'InvalidId');",
-    },
-    {
-      code: "const test = new TestClass('test', 'invalidId');",
-      errors: [{ messageId: "pascalCaseConstructId" }],
-      output: "const test = new TestClass('test', 'InvalidId');",
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', 'InvalidId');`,
     },
   ],
 });

--- a/src/no-class-in-interface-props.mts
+++ b/src/no-class-in-interface-props.mts
@@ -22,7 +22,7 @@ export const noClassInInterfaceProps = ESLintUtils.RuleCreator.withoutDocs({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
-    const checker = parserServices.program.getTypeChecker();
+    const typeChecker = parserServices.program.getTypeChecker();
     return {
       TSInterfaceDeclaration(node) {
         for (const property of node.body.body) {
@@ -35,7 +35,7 @@ export const noClassInInterfaceProps = ESLintUtils.RuleCreator.withoutDocs({
           }
 
           const tsNode = parserServices.esTreeNodeToTSNodeMap.get(property);
-          const type = checker.getTypeAtLocation(tsNode);
+          const type = typeChecker.getTypeAtLocation(tsNode);
           if (!type.symbol) continue;
 
           // NOTE: check class type

--- a/src/no-construct-stack-suffix.mts
+++ b/src/no-construct-stack-suffix.mts
@@ -32,10 +32,10 @@ export const noConstructStackSuffix = ESLintUtils.RuleCreator.withoutDocs({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
-    const checker = parserServices.program.getTypeChecker();
+    const typeChecker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = checker.getTypeAtLocation(
+        const type = typeChecker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(node)
         );
         if (!isConstructOrStackType(type)) {

--- a/src/no-mutable-public-fields.mts
+++ b/src/no-mutable-public-fields.mts
@@ -24,12 +24,12 @@ export const noMutablePublicFields = ESLintUtils.RuleCreator.withoutDocs({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
-    const checker = parserServices.program.getTypeChecker();
+    const typeChecker = parserServices.program.getTypeChecker();
     const sourceCode = context.sourceCode;
 
     return {
       ClassDeclaration(node) {
-        const type = checker.getTypeAtLocation(
+        const type = typeChecker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(node)
         );
         if (!isConstructOrStackType(type)) {

--- a/src/no-mutable-public-fields.mts
+++ b/src/no-mutable-public-fields.mts
@@ -1,5 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
+import { isConstructOrStackType } from "./utils/isConstructOrStackType.mjs";
+
 /**
  * Disallow mutable public class fields
  * @param context - The rule context provided by ESLint
@@ -21,9 +23,19 @@ export const noMutablePublicFields = ESLintUtils.RuleCreator.withoutDocs({
   },
   defaultOptions: [],
   create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     const sourceCode = context.sourceCode;
+
     return {
       ClassDeclaration(node) {
+        const type = checker.getTypeAtLocation(
+          parserServices.esTreeNodeToTSNodeMap.get(node)
+        );
+        if (!isConstructOrStackType(type)) {
+          return;
+        }
+
         for (const member of node.body.body) {
           // NOTE: check property definition
           if (

--- a/src/no-public-class-fields.mts
+++ b/src/no-public-class-fields.mts
@@ -7,6 +7,8 @@ import {
 } from "@typescript-eslint/utils";
 import { SymbolFlags, TypeChecker } from "typescript";
 
+import { isConstructOrStackType } from "./utils/isConstructOrStackType.mjs";
+
 type Context = TSESLint.RuleContext<"noPublicClassFields", []>;
 
 /**
@@ -33,6 +35,13 @@ export const noPublicClassFields = ESLintUtils.RuleCreator.withoutDocs({
     const typeChecker = parserServices.program.getTypeChecker();
     return {
       ClassDeclaration(node) {
+        const type = typeChecker.getTypeAtLocation(
+          parserServices.esTreeNodeToTSNodeMap.get(node)
+        );
+        if (!isConstructOrStackType(type)) {
+          return;
+        }
+
         // NOTE: Check class members
         validateClassMember({
           node,

--- a/src/pascal-case-construct-id.mts
+++ b/src/pascal-case-construct-id.mts
@@ -1,8 +1,12 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
-import { Rule } from "eslint";
-import { Expression, Node, SpreadElement } from "estree";
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESLint,
+  TSESTree,
+} from "@typescript-eslint/utils";
 
 import { toPascalCase } from "./utils/convertString.mjs";
+import { isConstructOrStackType } from "./utils/isConstructOrStackType.mjs";
 
 const QUOTE_TYPE = {
   SINGLE: "'",
@@ -11,13 +15,16 @@ const QUOTE_TYPE = {
 
 type QuoteType = (typeof QUOTE_TYPE)[keyof typeof QUOTE_TYPE];
 
+type Context = TSESLint.RuleContext<"pascalCaseConstructId", []>;
+
+/**
 /**
  * Enforce PascalCase for Construct ID.
  * @param context - The rule context provided by ESLint
  * @returns An object containing the AST visitor functions
  * @see {@link https://eslint-cdk-plugin.dev/rules/pascal-case-construct-id} - Documentation
  */
-export const pascalCaseConstructId: Rule.RuleModule = {
+export const pascalCaseConstructId = ESLintUtils.RuleCreator.withoutDocs({
   meta: {
     type: "problem",
     docs: {
@@ -29,22 +36,37 @@ export const pascalCaseConstructId: Rule.RuleModule = {
     schema: [],
     fixable: "code",
   },
+  defaultOptions: [],
   create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
-      ExpressionStatement(node) {
-        if (node.expression.type !== AST_NODE_TYPES.NewExpression) return;
-        validateConstructId(node, context, node.expression.arguments);
-      },
-      VariableDeclaration(node) {
-        if (!node.declarations.length) return;
-        for (const declaration of node.declarations) {
-          if (declaration.init?.type !== AST_NODE_TYPES.NewExpression) return;
-          validateConstructId(node, context, declaration.init.arguments);
+      // ExpressionStatement(node) {
+      //   if (node.expression.type !== AST_NODE_TYPES.NewExpression) return;
+      //   validateConstructId(node, context, node.expression.arguments);
+      // },
+      // VariableDeclaration(node) {
+      //   if (!node.declarations.length) return;
+      //   for (const declaration of node.declarations) {
+      //     if (declaration.init?.type !== AST_NODE_TYPES.NewExpression) return;
+      //     validateConstructId(node, context, declaration.init.arguments);
+      //   }
+      // },
+      NewExpression(node) {
+        const type = checker.getTypeAtLocation(
+          parserServices.esTreeNodeToTSNodeMap.get(node)
+        );
+        if (!isConstructOrStackType(type)) {
+          return;
         }
+
+        if (node.arguments.length < 2) return;
+
+        validateConstructId(node, context, node);
       },
     };
   },
-};
+});
 
 /**
  * check if the string is PascalCase
@@ -58,15 +80,15 @@ const isPascalCase = (str: string) => {
 /**
  * Check the construct ID is PascalCase
  */
-const validateConstructId = <T extends Node>(
-  node: T,
-  context: Rule.RuleContext,
-  args: (SpreadElement | Expression)[]
+const validateConstructId = (
+  node: TSESTree.Node,
+  context: Context,
+  expression: TSESTree.NewExpression
 ) => {
-  if (args.length < 2) return;
+  if (expression.arguments.length < 2) return;
 
   // NOTE: Treat the second argument as ID
-  const secondArg = args[1];
+  const secondArg = expression.arguments[1];
   if (
     secondArg.type !== AST_NODE_TYPES.Literal ||
     typeof secondArg.value !== "string"

--- a/src/pascal-case-construct-id.mts
+++ b/src/pascal-case-construct-id.mts
@@ -39,10 +39,10 @@ export const pascalCaseConstructId = ESLintUtils.RuleCreator.withoutDocs({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
-    const checker = parserServices.program.getTypeChecker();
+    const typeChecker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = checker.getTypeAtLocation(
+        const type = typeChecker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(node)
         );
         if (!isConstructOrStackType(type)) {

--- a/src/pascal-case-construct-id.mts
+++ b/src/pascal-case-construct-id.mts
@@ -41,17 +41,6 @@ export const pascalCaseConstructId = ESLintUtils.RuleCreator.withoutDocs({
     const parserServices = ESLintUtils.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
     return {
-      // ExpressionStatement(node) {
-      //   if (node.expression.type !== AST_NODE_TYPES.NewExpression) return;
-      //   validateConstructId(node, context, node.expression.arguments);
-      // },
-      // VariableDeclaration(node) {
-      //   if (!node.declarations.length) return;
-      //   for (const declaration of node.declarations) {
-      //     if (declaration.init?.type !== AST_NODE_TYPES.NewExpression) return;
-      //     validateConstructId(node, context, declaration.init.arguments);
-      //   }
-      // },
       NewExpression(node) {
         const type = checker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(node)

--- a/src/utils/isConstructOrStackType.mts
+++ b/src/utils/isConstructOrStackType.mts
@@ -1,0 +1,25 @@
+import { Type } from "typescript";
+
+export const SUPPORTED_SUPER_CLASS_SUFFIXES = ["Construct", "Stack"];
+
+/**
+ * Check if the type extends Construct or Stack
+ * @param type - The type to check
+ * @returns True if the type extends Construct or Stack, otherwise false
+ */
+export const isConstructOrStackType = (type: Type): boolean => {
+  if (!type.symbol) return false;
+
+  // NOTE: Check if the current type ends in Construct or Stack
+  if (
+    SUPPORTED_SUPER_CLASS_SUFFIXES.some((suffix) =>
+      type.symbol.name.endsWith(suffix)
+    )
+  ) {
+    return true;
+  }
+
+  // NOTE: Check the base type
+  const baseTypes = type.getBaseTypes() || [];
+  return baseTypes.some((baseType) => isConstructOrStackType(baseType));
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #54 

### Reason for this change

To make the rules more rigorous.

### Description of changes

The following rules prevent the application of rules to classes that do not inherit `Construct` or `Stack`

- no-construct-stack-suffix
- no-mutable-public-fields
- no-public-class-fields
- pascal-case-construct-id



### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
