### PR TITLE
feat: add rule 'no-variable-construct-id'

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -99,6 +99,10 @@ export default defineConfig({
                 link: "/rules/require-passing-this",
               },
               {
+                text: "no-variable-construct-id",
+                link: "/rules/no-variable-construct-id",
+              },
+              {
                 text: "no-parent-name-construct-id-match",
                 link: "/rules/no-parent-name-construct-id-match",
               },
@@ -171,6 +175,10 @@ export default defineConfig({
               {
                 text: "require-passing-this",
                 link: "/ja/rules/require-passing-this",
+              },
+              {
+                text: "no-variable-construct-id",
+                link: "/ja/rules/no-variable-construct-id",
               },
               {
                 text: "no-parent-name-construct-id-match",

--- a/docs/ja/rules/index.md
+++ b/docs/ja/rules/index.md
@@ -10,6 +10,7 @@ titleTemplate: ":title"
 
 - [pascal-case-construct-id](/ja/rules/pascal-case-construct-id)
 - [require-passing-this](/ja/rules/require-passing-this)
+- [no-variable-construct-id](/ja/rules/no-variable-construct-id)
 - [no-parent-name-construct-id-match](/ja/rules/no-parent-name-construct-id-match)
 - [no-construct-stack-suffix](/ja/rules/no-construct-stack-suffix)
 - [no-class-in-interface](/ja/rules/no-class-in-interface)
@@ -54,6 +55,7 @@ export default [
       "cdk/no-public-class-fields": "error",
       "cdk/pascal-case-construct-id": "error",
       "cdk/require-passing-this": "error",
+      "cdk/no-variable-construct-id": "error",
       "cdk/no-mutable-public-fields": "warn",
       "cdk/no-mutable-props-interface": "warn",
     },

--- a/docs/ja/rules/no-variable-construct-id.md
+++ b/docs/ja/rules/no-variable-construct-id.md
@@ -49,6 +49,10 @@ class MyConstruct extends Construct {
 ```ts
 import { Bucket } from "aws-cdk-lib/aws-s3";
 
+export interface MyConstructProps {
+  stage: string;
+}
+
 class MyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: MyConstructProps) {
     super(scope, id);
@@ -63,7 +67,7 @@ class MyConstruct extends Construct {
     new Bucket(this, id + "Bucket");
 
     // ❌ プロパティを直接使用しても問題です
-    new Bucket(this, `${prop.stage}Bucket`);
+    new Bucket(this, `${props.stage}Bucket`);
   }
 }
 ```

--- a/docs/ja/rules/no-variable-construct-id.md
+++ b/docs/ja/rules/no-variable-construct-id.md
@@ -1,0 +1,69 @@
+---
+title: eslint-cdk-plugin - no-variable-construct-id
+titleTemplate: ":title"
+---
+
+# no-variable-construct-id
+
+<div style="margin-top: 16px; background-color: #595959; padding: 16px; border-radius: 4px;">
+    ✅ <a href="/ja/rules/#recommended-rules">recommended</a>
+  を使用した場合、このルールが有効になります。
+</div>
+
+このルールは、コンストラクト ID に変数を使用しないことを強制するものです。  
+(このルールは `Construct` から継承したクラスにのみ適用されます)
+
+コンストラクト ID（論理 ID）に変数を使用することは、以下の問題を引き起こす可能性があるため適切ではありません  
+(ループ処理は対象外です）
+
+- 不要な重複
+- パラメータ変更時のリソース再作成
+- ID の一意性を重視するあまり、不要な文字列を混在させてしまう。
+
+#### ✅ 正しい例
+
+```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+export interface MyConstructProps {
+  environments: Record<string, string>;
+}
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+
+    // ✅ 文字列リテラルは使用できます
+    new Bucket(this, "Bucket");
+
+    // ✅ ループ変数は使用できます
+    for (const [key, value] of Object.entries(props.environments)) {
+      new Bucket(this, `${key}Bucket`);
+    }
+  }
+}
+```
+
+#### ❌ 不正な例
+
+```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+
+    // ❌ コンストラクトIDとしてパラメータを使用すべきではありません
+    new Bucket(this, id);
+
+    // ❌ パラメータをテンプレート文字列に組み合わせるべきではありません
+    new Bucket(this, `${id}Bucket`);
+
+    // ❌ パラメータを任意の式に組み合わせるべきではありません
+    new Bucket(this, id + "Bucket");
+
+    // ❌ プロパティを直接使用しても問題です
+    new Bucket(this, `${prop.stage}Bucket`);
+  }
+}
+```

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -10,6 +10,7 @@ You can check the details of the rules on each page.
 
 - [pascal-case-construct-id](/rules/pascal-case-construct-id)
 - [require-passing-this](/rules/require-passing-this)
+- [no-variable-construct-id](/rules/no-variable-construct-id)
 - [no-parent-name-construct-id-match](/rules/no-parent-name-construct-id-match)
 - [no-construct-stack-suffix](/rules/no-construct-stack-suffix)
 - [no-class-in-interface](/rules/no-class-in-interface)
@@ -54,6 +55,7 @@ export default [
       "cdk/no-public-class-fields": "error",
       "cdk/pascal-case-construct-id": "error",
       "cdk/require-passing-this": "error",
+      "cdk/no-variable-construct-id": "error",
       "cdk/no-mutable-public-fields": "warn",
       "cdk/no-mutable-props-interface": "warn",
     },

--- a/docs/rules/no-variable-construct-id.md
+++ b/docs/rules/no-variable-construct-id.md
@@ -50,6 +50,10 @@ class MyConstruct extends Construct {
 ```ts
 import { Bucket } from "aws-cdk-lib/aws-s3";
 
+export interface MyConstructProps {
+  stage: string;
+}
+
 class MyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: MyConstructProps) {
     super(scope, id);
@@ -64,7 +68,7 @@ class MyConstruct extends Construct {
     new Bucket(this, id + "Bucket");
 
     // ❌ Shouldn't use a prop straight-up either
-    new Bucket(this, `${prop.stage}Bucket`);
+    new Bucket(this, `${props.stage}Bucket`);
   }
 }
 ```

--- a/docs/rules/no-variable-construct-id.md
+++ b/docs/rules/no-variable-construct-id.md
@@ -1,0 +1,70 @@
+---
+title: eslint-cdk-plugin - no-variable-construct-id
+titleTemplate: ":title"
+---
+
+# no-variable-construct-id
+
+<div style="margin-top: 16px; background-color: #595959; padding: 16px; border-radius: 4px;">
+  ✅ Using
+  <a href="/rules/#recommended-rules">recommended</a>
+  in an ESLint configuration enables this rule.
+</div>
+
+This rule enforces the use of no variables in construct IDs.  
+(This rule applies only to classes that extends from `Construct`)
+
+Using variables for construct ID (logical ID) is not appropriate because it may cause the following problems.  
+(loop processing is not covered)
+
+- Unnecessary duplication
+- Resource recreation when the parameter is changed
+- Users mix unnecessary strings because they pay too much attention to the uniqueness of the ID
+
+#### ✅ Correct Example
+
+```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+export interface MyConstructProps {
+  environments: Record<string, string>;
+}
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+
+    // ✅ Can use a literal
+    new Bucket(this, "Bucket");
+
+    // ✅ Can use a loop variable
+    for (const [key, value] of Object.entries(props.environments)) {
+      new Bucket(this, `${key}Bucket`);
+    }
+  }
+}
+```
+
+#### ❌ Incorrect Example
+
+```ts
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+
+    // ❌ Shouldn't use a parameter as a construct ID
+    new Bucket(this, id);
+
+    // ❌ Shouldn't combine a parameter into a template string
+    new Bucket(this, `${id}Bucket`);
+
+    // ❌ Shouldn't combine a parameter into any expression
+    new Bucket(this, id + "Bucket");
+
+    // ❌ Shouldn't use a prop straight-up either
+    new Bucket(this, `${prop.stage}Bucket`);
+  }
+}
+```

--- a/src/__tests__/no-variable-construct-id.test.ts
+++ b/src/__tests__/no-variable-construct-id.test.ts
@@ -1,0 +1,183 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import { noVariableConstructId } from "../no-variable-construct-id.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["*.ts*"],
+      },
+    },
+  },
+});
+
+ruleTester.run("no-variable-construct-id", noVariableConstructId, {
+  valid: [
+    // WHEN: id is string literal
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new TargetConstruct(this, "SampleId");
+        }
+      }
+      `,
+    },
+    // WHEN: id is template literal, without expressions
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new TargetConstruct(this, \`SampleId\`);
+        }
+      }
+      `,
+    },
+    // WHEN: id is variable in a for...of loop
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const items = ['a', 'b', 'c'];
+          for (const item of items) {
+            new TargetConstruct(this, item);
+          }
+        }
+      }
+    `,
+    },
+    // WHEN: id is variable in a while loop
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const items = ['a', 'b', 'c'];
+          while (items.length > 0) {
+            new TargetConstruct(this, items.pop()!);
+          }
+        }
+      }
+    `,
+    },
+  ],
+  invalid: [
+    // WHEN: id is variable
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new TargetConstruct(this, id);
+        }
+      }
+      `,
+      errors: [{ messageId: "noVariableConstructId" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: { name: string}) {
+          super(scope, id);
+          new TargetConstruct(this, props.name);
+        }
+      }
+      `,
+      errors: [{ messageId: "noVariableConstructId" }],
+    },
+    // WHEN: id is template literal, with expressions
+    {
+      code: [
+        "class Construct {}",
+        "class TargetConstruct extends Construct {",
+        "  constructor(scope: Construct, id: string) {",
+        "    super(scope, id);",
+        "  }",
+        "}",
+        "class SampleConstruct extends Construct {",
+        "  constructor(scope: Construct, id: string) {",
+        "    super(scope, id);",
+        "    new TargetConstruct(this, `${id}Bucket`);",
+        "  }",
+        "}",
+      ].join("\n"),
+      errors: [{ messageId: "noVariableConstructId" }],
+    },
+    // WHEN: using the function
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new TargetConstruct(this, id + "Bucket");
+        }
+      }
+      `,
+      errors: [{ messageId: "noVariableConstructId" }],
+    },
+    {
+      code: `
+      const getId = () => "SampleId";
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new TargetConstruct(this, getId());
+        }
+      }
+      `,
+      errors: [{ messageId: "noVariableConstructId" }],
+    },
+  ],
+});

--- a/src/index.mts
+++ b/src/index.mts
@@ -5,6 +5,7 @@ import { noMutablePropsInterface } from "./no-mutable-props-interface.mjs";
 import { noMutablePublicFields } from "./no-mutable-public-fields.mjs";
 import { noParentNameConstructIdMatch } from "./no-parent-name-construct-id-match.mjs";
 import { noPublicClassFields } from "./no-public-class-fields.mjs";
+import { noVariableConstructId } from "./no-variable-construct-id.mjs";
 import { pascalCaseConstructId } from "./pascal-case-construct-id.mjs";
 import { requirePassingThis } from "./require-passing-this.mjs";
 
@@ -19,6 +20,7 @@ const plugin = {
     "no-mutable-public-fields": noMutablePublicFields,
     "no-mutable-props-interface": noMutablePropsInterface,
     "require-passing-this": requirePassingThis,
+    "no-variable-construct-id": noVariableConstructId,
   },
   configs: {
     recommended: {
@@ -30,6 +32,7 @@ const plugin = {
         "cdk/no-public-class-fields": "error",
         "cdk/pascal-case-construct-id": "error",
         "cdk/require-passing-this": "error",
+        "cdk/no-variable-construct-id": "error",
         "cdk/no-mutable-public-fields": "warn",
         "cdk/no-mutable-props-interface": "warn",
       },

--- a/src/no-variable-construct-id.mts
+++ b/src/no-variable-construct-id.mts
@@ -5,7 +5,7 @@ import {
   TSESTree,
 } from "@typescript-eslint/utils";
 
-import { isConstructOrStackType } from "./utils/typeCheck.mjs";
+import { isConstructType } from "./utils/typeCheck.mjs";
 
 type Context = TSESLint.RuleContext<"noVariableConstructId", []>;
 
@@ -35,7 +35,7 @@ export const noVariableConstructId = ESLintUtils.RuleCreator.withoutDocs({
         const type = typeChecker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(node)
         );
-        if (!isConstructOrStackType(type)) {
+        if (!isConstructType(type)) {
           return;
         }
 

--- a/src/no-variable-construct-id.mts
+++ b/src/no-variable-construct-id.mts
@@ -1,0 +1,105 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESLint,
+  TSESTree,
+} from "@typescript-eslint/utils";
+
+import { isConstructOrStackType } from "./utils/typeCheck.mjs";
+
+type Context = TSESLint.RuleContext<"noVariableConstructId", []>;
+
+/**
+ * Enforce using literal strings for Construct ID.
+ * @param context - The rule context provided by ESLint
+ * @returns An object containing the AST visitor functions
+ */
+export const noVariableConstructId = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: "problem",
+    docs: {
+      description: `Enforce using literal strings for Construct ID.`,
+    },
+    messages: {
+      noVariableConstructId: "Shouldn't use a parameter as a Construct ID.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const typeChecker = parserServices.program.getTypeChecker();
+
+    return {
+      NewExpression(node) {
+        const type = typeChecker.getTypeAtLocation(
+          parserServices.esTreeNodeToTSNodeMap.get(node)
+        );
+        if (!isConstructOrStackType(type)) {
+          return;
+        }
+
+        if (node.arguments.length < 2) return;
+
+        validateConstructId(node, context, node);
+      },
+    };
+  },
+});
+
+/**
+ * Check if the construct ID is a literal string
+ */
+const validateConstructId = (
+  node: TSESTree.Node,
+  context: Context,
+  expression: TSESTree.NewExpression
+) => {
+  if (expression.arguments.length < 2 || isInsideLoop(node)) {
+    return;
+  }
+
+  // NOTE: Treat the second argument as ID
+  const secondArg = expression.arguments[1];
+
+  // NOTE: When id is string literal, it's OK
+  if (
+    secondArg.type === AST_NODE_TYPES.Literal &&
+    typeof secondArg.value === "string"
+  ) {
+    return;
+  }
+
+  // NOTE: When id is template literal, only those without expressions are OK
+  if (
+    secondArg.type === AST_NODE_TYPES.TemplateLiteral &&
+    !secondArg.expressions.length
+  ) {
+    return;
+  }
+
+  context.report({
+    node,
+    messageId: "noVariableConstructId",
+  });
+};
+
+/**
+ * Check if the node is inside a loop statement
+ */
+const isInsideLoop = (node: TSESTree.Node): boolean => {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === AST_NODE_TYPES.ForStatement ||
+      current.type === AST_NODE_TYPES.ForInStatement ||
+      current.type === AST_NODE_TYPES.ForOfStatement ||
+      current.type === AST_NODE_TYPES.WhileStatement ||
+      current.type === AST_NODE_TYPES.DoWhileStatement
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #63 

### Reason for this change


To avoid the use of variables for Construct ID (logical ID), which can cause the following problems :

- Unnecessary duplication
- Resource re-creation occurs when parameters are changed
- Users are overly concerned about the uniqueness of IDs and mix in unnecessary strings

### Description of changes

- Added rule to make it an error if a variable is passed to Construct ID
  - Variables in loops like `for` and `while` are allowed.

### Description of how you validated changes

- [x] unit test
- [x] verify that the rules apply by actually using the system

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md) 

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
