### PR TITLE
fix: rules that should apply only to constructs also apply to stacks

### DIFF
--- a/src/no-variable-construct-id.mts
+++ b/src/no-variable-construct-id.mts
@@ -5,7 +5,7 @@ import {
   TSESTree,
 } from "@typescript-eslint/utils";
 
-import { isConstructType } from "./utils/typeCheck.mjs";
+import { isConstructType, isStackType } from "./utils/typeCheck.mjs";
 
 type Context = TSESLint.RuleContext<"noVariableConstructId", []>;
 
@@ -35,7 +35,7 @@ export const noVariableConstructId = ESLintUtils.RuleCreator.withoutDocs({
         const type = typeChecker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(node)
         );
-        if (!isConstructType(type)) {
+        if (!isConstructType(type) || isStackType(type)) {
           return;
         }
 

--- a/src/require-passing-this.mts
+++ b/src/require-passing-this.mts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
-import { isConstructType } from "./utils/typeCheck.mjs";
+import { isConstructType, isStackType } from "./utils/typeCheck.mjs";
 
 /**
  * Enforces that `this` is passed to the constructor
@@ -30,7 +30,11 @@ export const requirePassingThis = ESLintUtils.RuleCreator.withoutDocs({
           parserServices.esTreeNodeToTSNodeMap.get(node)
         );
 
-        if (!isConstructType(type) || !node.arguments.length) {
+        if (
+          !isConstructType(type) ||
+          isStackType(type) ||
+          !node.arguments.length
+        ) {
           return;
         }
 

--- a/src/utils/typeCheck.mts
+++ b/src/utils/typeCheck.mts
@@ -8,7 +8,11 @@ type SuperClassType = "Construct" | "Stack";
  * @returns True if the type extends Construct or Stack, otherwise false
  */
 export const isConstructOrStackType = (type: Type): boolean => {
-  return isTargetSuperClassType(type, ["Construct", "Stack"]);
+  return isTargetSuperClassType(
+    type,
+    ["Construct", "Stack"],
+    isConstructOrStackType
+  );
 };
 
 /**
@@ -17,7 +21,16 @@ export const isConstructOrStackType = (type: Type): boolean => {
  * @returns True if the type extends Construct, otherwise false
  */
 export const isConstructType = (type: Type): boolean => {
-  return isTargetSuperClassType(type, ["Construct"]);
+  return isTargetSuperClassType(type, ["Construct"], isConstructType);
+};
+
+/**
+ * Check if the type extends Stack
+ * @param type - The type to check
+ * @returns True if the type extends Stack, otherwise false
+ */
+export const isStackType = (type: Type): boolean => {
+  return isTargetSuperClassType(type, ["Stack"], isStackType);
 };
 
 /**
@@ -28,7 +41,8 @@ export const isConstructType = (type: Type): boolean => {
  */
 const isTargetSuperClassType = (
   type: Type,
-  targetSuperClasses: SuperClassType[]
+  targetSuperClasses: SuperClassType[],
+  typeCheckFunction: (type: Type) => boolean
 ): boolean => {
   if (!type.symbol) return false;
 
@@ -39,5 +53,5 @@ const isTargetSuperClassType = (
 
   // NOTE: Check the base type
   const baseTypes = type.getBaseTypes() || [];
-  return baseTypes.some((baseType) => isConstructOrStackType(baseType));
+  return baseTypes.some((baseType) => typeCheckFunction(baseType));
 };


### PR DESCRIPTION
### Issue # (if applicable)

Closes #78 

### Reason for this change

Because rules that should have applied only to constructs were also applied to stacks

### Description of changes

Added logic to verify that it is not a Stack to rules that apply only to Struct.


### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
