### PR TITLE
fix: check property names during instantiation

### DIFF
--- a/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/src/__tests__/no-construct-stack-suffix.test.ts
@@ -41,7 +41,7 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
     {
       code: `
       class TestClass {
-        constructor(public id: string) {}
+        constructor(props: any, id: string) {}
       }
       const test = new TestClass("test", "SampleConstruct");
       `,
@@ -49,13 +49,22 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
     {
       code: `
       class TestClass {
-        constructor(public id: string) {}
+        constructor(props: any, id: string) {}
       }
       class Sample {
         constructor() {
           const test = new TestClass("test", "SampleConstruct");
         }
       }`,
+    },
+    // WHEN: property name is not `id`
+    {
+      code: `
+      class TestClass {
+        constructor(props: any, validId: string) {}
+      }
+      const test = new TestClass("test", "SampleConstruct");
+      `,
     },
   ],
   invalid: [

--- a/src/__tests__/no-variable-construct-id.test.ts
+++ b/src/__tests__/no-variable-construct-id.test.ts
@@ -88,6 +88,23 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       }
     `,
     },
+    // WHEN: property name is not `id`
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, validId: string) {
+          super(scope, validId);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new TargetConstruct(this, id);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: id is variable

--- a/src/__tests__/pascal-case-construct-id.test.ts
+++ b/src/__tests__/pascal-case-construct-id.test.ts
@@ -79,6 +79,17 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       }
       const test = new TestClass('test', 'ValidId');`,
     },
+    // WHEN: property name is not `id`
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, validId: string) {
+          super(props, validId);
+        }
+      }
+      const test = new TestClass("test", "invalid_id");`,
+    },
   ],
   invalid: [
     // WHEN: id is snake_case(double quote)

--- a/src/__tests__/require-passing-this.test.ts
+++ b/src/__tests__/require-passing-this.test.ts
@@ -48,6 +48,23 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       }
       `,
     },
+    // WHEN: property name is not `scope`
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(validProperty: Construct, id: string) {
+          super(validProperty, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleConstruct(scope, "ValidId");
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: not passing `this` to a constructor

--- a/src/rules/no-construct-stack-suffix.ts
+++ b/src/rules/no-construct-stack-suffix.ts
@@ -6,6 +6,7 @@ import {
 } from "@typescript-eslint/utils";
 
 import { toPascalCase } from "../utils/convertString";
+import { getConstructorPropertyNames } from "../utils/parseType";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
 type Context = TSESLint.RuleContext<"noConstructStackSuffix", []>;
@@ -38,6 +39,10 @@ export const noConstructStackSuffix = ESLintUtils.RuleCreator.withoutDocs({
         if (!isConstructOrStackType(type) || node.arguments.length < 2) {
           return;
         }
+
+        const constructorPropertyNames = getConstructorPropertyNames(type);
+        if (constructorPropertyNames[1] !== "id") return;
+
         validateConstructId(node, context);
       },
     };

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -5,6 +5,7 @@ import {
   TSESTree,
 } from "@typescript-eslint/utils";
 
+import { getConstructorPropertyNames } from "../utils/parseType";
 import { isConstructType, isStackType } from "../utils/typeCheck";
 
 type Context = TSESLint.RuleContext<"noVariableConstructId", []>;
@@ -39,6 +40,9 @@ export const noVariableConstructId = ESLintUtils.RuleCreator.withoutDocs({
         ) {
           return;
         }
+
+        const constructorPropertyNames = getConstructorPropertyNames(type);
+        if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);
       },

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -6,6 +6,7 @@ import {
 } from "@typescript-eslint/utils";
 
 import { toPascalCase } from "../utils/convertString";
+import { getConstructorPropertyNames } from "../utils/parseType";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
 const QUOTE_TYPE = {
@@ -45,6 +46,10 @@ export const pascalCaseConstructId = ESLintUtils.RuleCreator.withoutDocs({
         if (!isConstructOrStackType(type) || node.arguments.length < 2) {
           return;
         }
+
+        const constructorPropertyNames = getConstructorPropertyNames(type);
+        if (constructorPropertyNames[1] !== "id") return;
+
         validateConstructId(node, context);
       },
     };

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -24,7 +24,6 @@ export const requirePassingThis = ESLintUtils.RuleCreator.withoutDocs({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
-
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
-import { getConstructorPropertyNames } from "../utils/parseNode";
+import { getConstructorPropertyNames } from "../utils/parseType";
 import { isConstructType, isStackType } from "../utils/typeCheck";
 
 /**

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,5 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
+import { getConstructorPropertyNames } from "../utils/parseNode";
 import { isConstructType, isStackType } from "../utils/typeCheck";
 
 /**
@@ -23,6 +24,7 @@ export const requirePassingThis = ESLintUtils.RuleCreator.withoutDocs({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
@@ -37,6 +39,9 @@ export const requirePassingThis = ESLintUtils.RuleCreator.withoutDocs({
 
         const argument = node.arguments[0];
         if (argument.type === AST_NODE_TYPES.ThisExpression) return;
+
+        const constructorPropertyNames = getConstructorPropertyNames(type);
+        if (constructorPropertyNames[0] !== "scope") return;
 
         context.report({
           node,

--- a/src/utils/parseType.ts
+++ b/src/utils/parseType.ts
@@ -1,0 +1,19 @@
+import { isClassDeclaration, isConstructorDeclaration, Type } from "typescript";
+
+/**
+ * Parses type to get the property names of the class constructor.
+ */
+export const getConstructorPropertyNames = (type: Type): string[] => {
+  const declarations = type.symbol?.declarations;
+  if (!declarations?.length) return [];
+
+  const classDeclaration = declarations[0];
+  if (!isClassDeclaration(classDeclaration)) return [];
+
+  const constructor = classDeclaration.members.find((member) =>
+    isConstructorDeclaration(member)
+  );
+  if (!constructor?.parameters.length) return [];
+
+  return constructor.parameters.map((param) => param.name.getText());
+};

--- a/src/utils/parseType.ts
+++ b/src/utils/parseType.ts
@@ -2,6 +2,7 @@ import { isClassDeclaration, isConstructorDeclaration, Type } from "typescript";
 
 /**
  * Parses type to get the property names of the class constructor.
+ * @returns The property names of the class constructor.
  */
 export const getConstructorPropertyNames = (type: Type): string[] => {
   const declarations = type.symbol?.declarations;


### PR DESCRIPTION
### Issue # (if applicable)

Closes #93 

### Reason for this change

Some rules did not check property names, resulting in unexpected errors

### Description of changes

- check the constructor's property names at following rules
  - no-construct-stack-suffix
  - no-variable-construct-id
  - pascal-case-construct-id
  - require-passing-this

### Description of how you validated changes

- unit test

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
