### PR TITLE
feat: add `props-name-convention` rule

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -134,6 +134,10 @@ export default defineConfig({
                 link: "/rules/require-props-default-doc",
               },
               {
+                text: "props-name-convention",
+                link: "/rules/props-name-convention",
+              },
+              {
                 text: "no-import-private",
                 link: "/rules/no-import-private",
               },
@@ -217,6 +221,10 @@ export default defineConfig({
               {
                 text: "require-props-default-doc",
                 link: "/ja/rules/require-props-default-doc",
+              },
+              {
+                text: "props-name-convention",
+                link: "/ja/rules/props-name-convention",
               },
               {
                 text: "no-import-private",

--- a/docs/ja/rules/index.md
+++ b/docs/ja/rules/index.md
@@ -19,4 +19,5 @@ titleTemplate: ":title"
 - [no-mutable-props-interface](/ja/rules/no-mutable-props-interface)
 - [require-jsdoc](/ja/rules/require-jsdoc)
 - [require-props-default-doc](/ja/rules/require-props-default-doc)
+- [props-name-convention](/ja/rules/props-name-convention)
 - [no-import-private](/ja/rules/no-import-private)

--- a/docs/ja/rules/props-name-convention.md
+++ b/docs/ja/rules/props-name-convention.md
@@ -1,0 +1,52 @@
+---
+title: eslint-cdk-plugin - props-name-convention
+titleTemplate: ":title"
+---
+
+# props-name-convention
+
+Construct クラスの Props(interface) 名が `${ConstructName}Props` の形式に従うことを強制します。  
+ここで、`${ConstructName}` は Construct クラスの名前です。
+
+一貫した命名パターンに従うことで、Construct とその Props(interface) の関係が明確になり、コードの保守性と理解のしやすさが向上します。
+
+#### ✅ 正しい例
+
+```ts
+// ✅ Props(interface) 名が`${ConstructName}Props`の形式に従っている
+interface MyConstructProps {
+  readonly bucket?: IBucket;
+}
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+  }
+}
+```
+
+```ts
+// ✅ Construct クラスではない interface には、このルールは適用されません
+interface SampleInterface {
+  readonly bucket?: IBucket;
+}
+
+class NotConstruct {
+  constructor(props: SampleInterface) {}
+}
+```
+
+#### ❌ 誤った例
+
+```ts
+// ❌ Props(interface) 名は `${ConstructName}Props` の形式に従う必要があります
+interface Props {
+  readonly bucket?: IBucket;
+}
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: Props) {
+    super(scope, id);
+  }
+}
+```

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -19,4 +19,5 @@ You can check the details of the rules on each page.
 - [no-mutable-props-interface](/rules/no-mutable-props-interface)
 - [require-jsdoc](/rules/require-jsdoc)
 - [require-props-default-doc](/rules/require-props-default-doc)
+- [props-name-convention](/rules/props-name-convention)
 - [no-import-private](/rules/no-import-private)

--- a/docs/rules/props-name-convention.md
+++ b/docs/rules/props-name-convention.md
@@ -1,0 +1,52 @@
+---
+title: eslint-cdk-plugin - props-name-convention
+titleTemplate: ":title"
+---
+
+# props-name-convention
+
+Forces the Props(interface) name of the Construct class to follow the form `${ConstructName}Props`.  
+Where `${ConstructName}` is the name of the Construct class.
+
+Following a consistent naming pattern clarifies the relationship between Construct and its Props(interface), improving code maintainability and ease of understanding.
+
+#### ✅ Correct Examples
+
+```ts
+// ✅ Props(interface) name follows the format of `${ConstructName}Props`
+interface MyConstructProps {
+  readonly bucket?: IBucket;
+}
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+  }
+}
+```
+
+```ts
+// ✅ This rule does not apply to interfaces that are not Construct classes
+interface Props {
+  readonly bucket?: string;
+}
+
+class NotConstruct {
+  constructor(props: Props) {}
+}
+```
+
+#### ❌ Incorrect Examples
+
+```ts
+interface Props {
+  // ❌ Props interface name must follow ${ConstructName}Props format
+  readonly bucket?: string;
+}
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: Props) {
+    super(scope, id);
+  }
+}
+```

--- a/src/__tests__/props-name-convention.test.ts
+++ b/src/__tests__/props-name-convention.test.ts
@@ -1,0 +1,102 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import { propsNameConvention } from "../rules/props-name-convention";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["*.ts*"],
+      },
+    },
+  },
+});
+
+ruleTester.run("props-name-convention", propsNameConvention, {
+  valid: [
+    {
+      // WHEN: Props interface name follows ${ConstructName}Props format
+      code: `
+        class Construct {}
+        interface MyConstructProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: MyConstructProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: Class is not a Construct
+      code: `
+        interface Props {
+          readonly bucket?: string;
+        }
+        class NotConstruct {
+          constructor(props: Props) {}
+        }
+      `,
+    },
+    {
+      // WHEN: Class has no props parameter
+      code: `
+        class Construct {}
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      // WHEN: Props interface name does not follow ${ConstructName}Props format
+      code: `
+        class Construct {}
+        interface Props {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: Props) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "Props",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
+      // WHEN: Props interface name has wrong prefix
+      code: `
+        class Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "WrongProps",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { noParentNameConstructIdMatch } from "./rules/no-parent-name-construct-i
 import { noPublicClassFields } from "./rules/no-public-class-fields";
 import { noVariableConstructId } from "./rules/no-variable-construct-id";
 import { pascalCaseConstructId } from "./rules/pascal-case-construct-id";
+import { propsNameConvention } from "./rules/props-name-convention";
 import { requireJSDoc } from "./rules/require-jsdoc";
 import { requirePassingThis } from "./rules/require-passing-this";
 import { requirePropsDefaultDoc } from "./rules/require-props-default-doc";
@@ -23,6 +24,7 @@ const rules = {
   "no-variable-construct-id": noVariableConstructId,
   "require-jsdoc": requireJSDoc,
   "require-props-default-doc": requirePropsDefaultDoc,
+  "props-name-convention": propsNameConvention,
   "no-import-private": noImportPrivate,
 };
 
@@ -39,6 +41,7 @@ const configs = {
       "cdk/no-variable-construct-id": "error",
       "cdk/no-mutable-public-fields": "warn",
       "cdk/no-mutable-props-interface": "warn",
+      "cdk/props-name-convention": "warn",
     },
   },
   strict: {
@@ -55,6 +58,7 @@ const configs = {
       "cdk/no-mutable-props-interface": "error",
       "cdk/no-import-private": "error",
       "cdk/require-props-default-doc": "error",
+      "cdk/props-name-convention": "error",
       "cdk/require-jsdoc": "error",
     },
   },

--- a/src/rules/props-name-convention.ts
+++ b/src/rules/props-name-convention.ts
@@ -1,0 +1,75 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from "@typescript-eslint/utils";
+
+import { isConstructType } from "../utils/typeCheck";
+
+/**
+ * Enforces a naming convention for props interfaces in Construct classes
+ * @param context - The rule context provided by ESLint
+ * @returns An object containing the AST visitor functions
+ * @see {@link https://eslint-cdk-plugin.dev/rules/props-name-convention} - Documentation
+ */
+export const propsNameConvention = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce props interface name to follow ${ConstructName}Props format",
+    },
+    schema: [],
+    messages: {
+      invalidPropsName:
+        "Props interface name '{{ interfaceName }}' should follow '${ConstructName}Props' format. Expected '{{ expectedName }}'.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    return {
+      ClassDeclaration(node) {
+        if (!node.id || !node.superClass) return;
+
+        const type = parserServices.getTypeAtLocation(node.superClass);
+        if (!isConstructType(type)) return;
+
+        // NOTE: check constructor parameter
+        const constructor = node.body.body.find(
+          (member): member is TSESTree.MethodDefinition =>
+            member.type === AST_NODE_TYPES.MethodDefinition &&
+            member.kind === "constructor"
+        );
+
+        const propsParam = constructor?.value.params?.[2];
+        if (propsParam?.type !== AST_NODE_TYPES.Identifier) return;
+
+        const typeAnnotation = propsParam.typeAnnotation;
+        if (typeAnnotation?.type !== AST_NODE_TYPES.TSTypeAnnotation) return;
+
+        const typeNode = typeAnnotation.typeAnnotation;
+        if (typeNode.type !== AST_NODE_TYPES.TSTypeReference) return;
+
+        const propsTypeName = typeNode.typeName;
+        if (propsTypeName.type !== AST_NODE_TYPES.Identifier) return;
+
+        // NOTE: create valid props name
+        const constructName = node.id.name;
+        const expectedPropsName = `${constructName}Props`;
+
+        // NOTE: error when props name is not expected format
+        if (propsTypeName.name !== expectedPropsName) {
+          context.report({
+            node: propsTypeName,
+            messageId: "invalidPropsName",
+            data: {
+              interfaceName: propsTypeName.name,
+              expectedName: expectedPropsName,
+            },
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
### Issue # (if applicable)

Closes #100 

### Reason for this change

Uniform naming of Construct props enhances code readability

### Description of changes

- add `props-name-convention` rule
- add unit test
- add docs

### Description of how you validated changes

- unit test

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
