### PR TITLE
feat: be more specific in code line for suggestion

### DIFF
--- a/src/rules/construct-constructor-property.ts
+++ b/src/rules/construct-constructor-property.ts
@@ -67,7 +67,7 @@ const validateConstructorProperty = (
   // NOTE: Check if the constructor has at least 2 parameters
   if (params.length < 2) {
     context.report({
-      node: constructor,
+      node: constructor.value,
       messageId: "invalidConstructorProperty",
     });
     return;
@@ -80,7 +80,7 @@ const validateConstructorProperty = (
     firstParam.name !== "scope"
   ) {
     context.report({
-      node: constructor,
+      node: firstParam,
       messageId: "invalidConstructorProperty",
     });
     return;
@@ -93,7 +93,7 @@ const validateConstructorProperty = (
     secondParam.name !== "id"
   ) {
     context.report({
-      node: constructor,
+      node: secondParam,
       messageId: "invalidConstructorProperty",
     });
     return;
@@ -109,7 +109,7 @@ const validateConstructorProperty = (
     thirdParam.name !== "props"
   ) {
     context.report({
-      node: constructor,
+      node: thirdParam,
       messageId: "invalidConstructorProperty",
     });
     return;

--- a/src/rules/no-construct-stack-suffix.ts
+++ b/src/rules/no-construct-stack-suffix.ts
@@ -110,7 +110,7 @@ const validateConstructId = (
     formattedConstructId.endsWith(SUFFIX_TYPE.CONSTRUCT)
   ) {
     context.report({
-      node,
+      node: secondArg,
       messageId: "noConstructStackSuffix",
       data: {
         classType: "Construct",
@@ -123,7 +123,7 @@ const validateConstructId = (
     formattedConstructId.endsWith(SUFFIX_TYPE.STACK)
   ) {
     context.report({
-      node,
+      node: secondArg,
       messageId: "noConstructStackSuffix",
       data: {
         classType: "Stack",

--- a/src/rules/no-parent-name-construct-id-match.ts
+++ b/src/rules/no-parent-name-construct-id-match.ts
@@ -18,7 +18,6 @@ type Options = [
 type Context = TSESLint.RuleContext<"noParentNameConstructIdMatch", Options>;
 
 type ValidateStatementArgs<T extends TSESTree.Statement> = {
-  node: TSESTree.ClassBody;
   statement: T;
   parentClassName: string;
   context: Context;
@@ -27,7 +26,6 @@ type ValidateStatementArgs<T extends TSESTree.Statement> = {
 };
 
 type ValidateExpressionArgs<T extends TSESTree.Expression> = {
-  node: TSESTree.ClassBody;
   expression: T;
   parentClassName: string;
   context: Context;
@@ -99,7 +97,6 @@ export const noParentNameConstructIdMatch = ESLintUtils.RuleCreator.withoutDocs(
               continue;
             }
             validateConstructorBody({
-              node,
               expression: body.value,
               parentClassName,
               context,
@@ -118,7 +115,6 @@ export const noParentNameConstructIdMatch = ESLintUtils.RuleCreator.withoutDocs(
  * - validate each statement in the constructor body
  */
 const validateConstructorBody = ({
-  node,
   expression,
   parentClassName,
   context,
@@ -131,7 +127,6 @@ const validateConstructorBody = ({
         const newExpression = statement.declarations[0].init;
         if (newExpression?.type !== AST_NODE_TYPES.NewExpression) continue;
         validateConstructId({
-          node,
           context,
           expression: newExpression,
           parentClassName,
@@ -143,7 +138,6 @@ const validateConstructorBody = ({
       case AST_NODE_TYPES.ExpressionStatement: {
         if (statement.expression?.type !== AST_NODE_TYPES.NewExpression) break;
         validateStatement({
-          node,
           statement,
           parentClassName,
           context,
@@ -154,7 +148,6 @@ const validateConstructorBody = ({
       }
       case AST_NODE_TYPES.IfStatement: {
         traverseStatements({
-          node,
           context,
           parentClassName,
           statement: statement.consequent,
@@ -167,7 +160,6 @@ const validateConstructorBody = ({
         for (const switchCase of statement.cases) {
           for (const statement of switchCase.consequent) {
             traverseStatements({
-              node,
               context,
               parentClassName,
               statement,
@@ -188,7 +180,6 @@ const validateConstructorBody = ({
  * - Validates construct IDs against parent class name
  */
 const traverseStatements = ({
-  node,
   statement,
   parentClassName,
   context,
@@ -199,7 +190,6 @@ const traverseStatements = ({
     case AST_NODE_TYPES.BlockStatement: {
       for (const body of statement.body) {
         validateStatement({
-          node,
           statement: body,
           parentClassName,
           context,
@@ -213,7 +203,6 @@ const traverseStatements = ({
       const newExpression = statement.expression;
       if (newExpression?.type !== AST_NODE_TYPES.NewExpression) break;
       validateStatement({
-        node,
         statement,
         parentClassName,
         context,
@@ -226,7 +215,6 @@ const traverseStatements = ({
       const newExpression = statement.declarations[0].init;
       if (newExpression?.type !== AST_NODE_TYPES.NewExpression) break;
       validateConstructId({
-        node,
         context,
         expression: newExpression,
         parentClassName,
@@ -244,7 +232,6 @@ const traverseStatements = ({
  * - Extracts and validates construct IDs from new expressions
  */
 const validateStatement = ({
-  node,
   statement,
   parentClassName,
   context,
@@ -256,7 +243,6 @@ const validateStatement = ({
       const newExpression = statement.declarations[0].init;
       if (newExpression?.type !== AST_NODE_TYPES.NewExpression) break;
       validateConstructId({
-        node,
         context,
         expression: newExpression,
         parentClassName,
@@ -269,7 +255,6 @@ const validateStatement = ({
       const newExpression = statement.expression;
       if (newExpression?.type !== AST_NODE_TYPES.NewExpression) break;
       validateConstructId({
-        node,
         context,
         expression: newExpression,
         parentClassName,
@@ -280,7 +265,6 @@ const validateStatement = ({
     }
     case AST_NODE_TYPES.IfStatement: {
       validateIfStatement({
-        node,
         statement,
         parentClassName,
         context,
@@ -291,7 +275,6 @@ const validateStatement = ({
     }
     case AST_NODE_TYPES.SwitchStatement: {
       validateSwitchStatement({
-        node,
         statement,
         parentClassName,
         context,
@@ -308,7 +291,6 @@ const validateStatement = ({
  * - Validate recursively if `if` statements are nested
  */
 const validateIfStatement = ({
-  node,
   statement,
   parentClassName,
   context,
@@ -316,7 +298,6 @@ const validateIfStatement = ({
   option,
 }: ValidateStatementArgs<TSESTree.IfStatement>): void => {
   traverseStatements({
-    node,
     context,
     parentClassName,
     statement: statement.consequent,
@@ -330,7 +311,6 @@ const validateIfStatement = ({
  * - Validate recursively if `switch` statements are nested
  */
 const validateSwitchStatement = ({
-  node,
   statement,
   parentClassName,
   context,
@@ -340,7 +320,6 @@ const validateSwitchStatement = ({
   for (const caseStatement of statement.cases) {
     for (const _consequent of caseStatement.consequent) {
       traverseStatements({
-        node,
         context,
         parentClassName,
         statement: _consequent,
@@ -355,7 +334,6 @@ const validateSwitchStatement = ({
  * Validate that parent construct name and child id do not match
  */
 const validateConstructId = ({
-  node,
   context,
   expression,
   parentClassName,
@@ -385,7 +363,7 @@ const validateConstructId = ({
     formattedConstructId.includes(formattedParentClassName)
   ) {
     context.report({
-      node,
+      node: secondArg,
       messageId: "noParentNameConstructIdMatch",
       data: {
         constructId: secondArg.value,
@@ -396,7 +374,7 @@ const validateConstructId = ({
   }
   if (formattedParentClassName === formattedConstructId) {
     context.report({
-      node,
+      node: secondArg,
       messageId: "noParentNameConstructIdMatch",
       data: {
         constructId: secondArg.value,

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -73,7 +73,7 @@ const validateConstructId = (
   }
 
   context.report({
-    node,
+    node: secondArg,
     messageId: "noVariableConstructId",
   });
 };

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -90,7 +90,7 @@ const validateConstructId = (
   if (isPascalCase(secondArg.value)) return;
 
   context.report({
-    node,
+    node: secondArg,
     messageId: "pascalCaseConstructId",
     fix: (fixer) => {
       const pascalCaseValue = toPascalCase(secondArg.value);

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -72,7 +72,7 @@ export const requirePassingThis = ESLintUtils.RuleCreator.withoutDocs({
         // NOTE: If `allowNonThisAndDisallowScope` is false, require `this` for all cases
         if (!options.allowNonThisAndDisallowScope) {
           context.report({
-            node,
+            node: argument,
             messageId: "requirePassingThis",
             fix: (fixer) => {
               return fixer.replaceText(argument, "this");
@@ -87,7 +87,7 @@ export const requirePassingThis = ESLintUtils.RuleCreator.withoutDocs({
           argument.name === "scope"
         ) {
           context.report({
-            node,
+            node: argument,
             messageId: "requirePassingThis",
             fix: (fixer) => {
               return fixer.replaceText(argument, "this");


### PR DESCRIPTION
### Issue # (if applicable)

Closes N/A

### Reason for this change

The current implementation has been suggesting many lines when there is code that violates the rules. (as shown in the image below).

#### Before Suggestion

![スクリーンショット 2025-05-11 19 10 43](https://github.com/user-attachments/assets/636e38fe-a4db-430f-8780-a03db5ea38b8)


This is not a good experience for the user, so I modified it to suggest more specific parts.

### Description of changes

Changed the value passed to the `node` property of eslint's `context.report` function

(We can see that the suggestions are more specific after the implementation modification as follows)

#### After Suggestion

![スクリーンショット 2025-05-11 19 14 41](https://github.com/user-attachments/assets/67b9de6b-c2d1-4a64-af12-01dce121dbb6)


### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
