### PR TITLE
fix: "no-construct-in-public-property-of-construct" and "no-class-in-interface"

### DIFF
--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -50,6 +50,16 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
     },
+    // WHEN: property type is interface that extends Construct
+    {
+      code: `
+      interface IConstruct {}
+      interface SampleInterface extends IConstruct {}
+      interface TestInterface {
+        test: SampleInterface;
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -89,6 +89,16 @@ ruleTester.run(
           }
         `,
       },
+      // WHEN: public field uses interface that extends Construct
+      {
+        code: `
+          class IConstruct {}
+          interface ITestClass extends IConstruct {}
+          class TestClass extends Construct {
+            public test: ITestClass;
+          }
+        `,
+      },
     ],
     invalid: [
       // WHEN: public field uses Construct type

--- a/src/rules/no-construct-in-interface.ts
+++ b/src/rules/no-construct-in-interface.ts
@@ -1,5 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
+import { SYMBOL_FLAGS } from "../constants/tsInternalFlags";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
 /**
@@ -36,6 +37,12 @@ export const noConstructInInterface = ESLintUtils.RuleCreator.withoutDocs({
 
           const type = parserServices.getTypeAtLocation(property);
           if (!isConstructOrStackType(type)) continue;
+
+          // NOTE: In order not to make it dependent on the typescript library, it defines its own unions.
+          //       Therefore, the type information structures do not match.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+          const isClass = type.symbol.flags === SYMBOL_FLAGS.CLASS;
+          if (!isClass) continue;
 
           context.report({
             node: property,

--- a/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/src/rules/no-construct-in-public-property-of-construct.ts
@@ -6,12 +6,10 @@ import {
   TSESTree,
 } from "@typescript-eslint/utils";
 
+import { SYMBOL_FLAGS } from "../constants/tsInternalFlags";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
-type Context = TSESLint.RuleContext<
-  "invalidPublicPropertyOfConstruct",
-  []
->;
+type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
 
 /**
  * Disallow Construct types in public property of Construct
@@ -94,6 +92,12 @@ const validatePublicPropertyOfConstruct = (
     const type = parserServices.getTypeAtLocation(property);
     if (!isConstructOrStackType(type)) continue;
 
+    // NOTE: In order not to make it dependent on the typescript library, it defines its own unions.
+    //       Therefore, the type information structures do not match.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+    const isClass = type.symbol.flags === SYMBOL_FLAGS.CLASS;
+    if (!isClass) continue;
+
     context.report({
       node: property,
       messageId: "invalidPublicPropertyOfConstruct",
@@ -132,6 +136,12 @@ const validateConstructorParameterProperty = (
 
     const type = parserServices.getTypeAtLocation(param);
     if (!isConstructOrStackType(type)) continue;
+
+    // NOTE: In order not to make it dependent on the typescript library, it defines its own unions.
+    //       Therefore, the type information structures do not match.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+    const isClass = type.symbol.flags === SYMBOL_FLAGS.CLASS;
+    if (!isClass) continue;
 
     context.report({
       node: param,


### PR DESCRIPTION
### Issue # (if applicable)

Closes N/A

### Reason for this change

- Fixed bugs in the following rules
  - no-construct-in-public-property-of-construct
  - no-class-in-interface

### Description of changes

Fixed a bug that an error occurred when using `Construct` type Interface such as `IBucket` as a property.


### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
