### PR TITLE
chore: release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [3.0.1](https://github.com/ren-yamanashi/eslint-cdk-plugin/compare/v3.0.0...v3.0.1) (2025-05-19)
+### [3.0.2](https://github.com/ren-yamanashi/eslint-cdk-plugin/compare/v3.0.0...v3.0.2) (2025-05-19)
 
 ### Bug fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-cdk-plugin",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "eslint plugin for AWS CDK projects",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Mistook `v3.0.1` for `v3.0.2` release.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
