### PR TITLE
feat: add no-unused-props rule for CDK construct props validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist/
 examples/
 .DS_Store
 *.tgz
-.cursor/
+.claude/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -123,6 +123,10 @@ export default defineConfig({
                 link: "/rules/no-parent-name-construct-id-match",
               },
               {
+                text: "no-unused-props",
+                link: "/rules/no-unused-props",
+              },
+              {
                 text: "no-variable-construct-id",
                 link: "/rules/no-variable-construct-id",
               },
@@ -219,6 +223,10 @@ export default defineConfig({
               {
                 text: "no-parent-name-construct-id-match",
                 link: "/ja/rules/no-parent-name-construct-id-match",
+              },
+              {
+                text: "no-unused-props",
+                link: "/ja/rules/no-unused-props",
               },
               {
                 text: "no-variable-construct-id",

--- a/docs/components/NextRecommendedItem.vue
+++ b/docs/components/NextRecommendedItem.vue
@@ -4,22 +4,26 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  version: {
+    type: String,
+    required: true,
+  },
 });
 </script>
 
 <template>
   <template v-if="props.japanese">
     <div class="info-item">
-      ℹ️ このルールは
+      ℹ️ このルールは {{ props.version }} で
       <a href="/ja/rules/#recommended-rules"> recommended </a>
-      ルールには含まれていません。
+      ルールに含まれます。
     </div>
   </template>
   <template v-else>
     <div class="info-item">
-      ℹ️ This rule is not included in the
+      ℹ️ This rule will be included in
       <a href="/rules/#recommended-rules"> recommended </a>
-      rules.
+      rules in {{ props.version }}.
     </div>
   </template>
 </template>

--- a/docs/ja/rules/index.md
+++ b/docs/ja/rules/index.md
@@ -138,6 +138,13 @@ import RuleItem from '../../components/RuleItem.vue'
     :isFixable="false"
   />
   <RuleItem
+    name="no-unused-props"
+    description="CDK Construct のpropsインターフェースで定義されたすべてのプロパティがコンストラクタ内で使用されることを強制します"
+    link="/ja/rules/no-unused-props"
+    :isRecommended="true"
+    :isFixable="false"
+  />
+  <RuleItem
     name="no-variable-construct-id"
     description="Construct ID に変数を使用しないように強制します"
     link="/ja/rules/no-variable-construct-id"

--- a/docs/ja/rules/index.md
+++ b/docs/ja/rules/index.md
@@ -141,7 +141,7 @@ import RuleItem from '../../components/RuleItem.vue'
     name="no-unused-props"
     description="CDK Construct のpropsインターフェースで定義されたすべてのプロパティがコンストラクタ内で使用されることを強制します"
     link="/ja/rules/no-unused-props"
-    :isRecommended="true"
+    :isRecommended="false"
     :isFixable="false"
   />
   <RuleItem

--- a/docs/ja/rules/index.md
+++ b/docs/ja/rules/index.md
@@ -118,7 +118,7 @@ import RuleItem from '../../components/RuleItem.vue'
   />
   <RuleItem
     name="no-mutable-property-of-props-interface"
-    description="Props(interface) のプロパティに readonly を指定することを強制します"
+    description="Props (interface) のプロパティに readonly を指定することを強制します"
     link="/ja/rules/no-mutable-property-of-props-interface"
     :isRecommended="true"
     :isFixable="true"
@@ -139,7 +139,7 @@ import RuleItem from '../../components/RuleItem.vue'
   />
   <RuleItem
     name="no-unused-props"
-    description="CDK Construct のpropsインターフェースで定義されたすべてのプロパティがコンストラクタ内で使用されることを強制します"
+    description="Construct の Props (interface) に定義されたすべてのプロパティがコンストラクタ内で使用されることを強制します"
     link="/ja/rules/no-unused-props"
     :isRecommended="false"
     :isFixable="false"
@@ -160,7 +160,7 @@ import RuleItem from '../../components/RuleItem.vue'
   />
   <RuleItem
     name="props-name-convention"
-    description="Props(interface) 名が ${ConstructName}Props の形式に従うことを強制します"
+    description="Props (interface) 名が ${ConstructName}Props の形式に従うことを強制します"
     link="/ja/rules/props-name-convention"
     :isRecommended="false"
     :isFixable="false"
@@ -181,7 +181,7 @@ import RuleItem from '../../components/RuleItem.vue'
   />
   <RuleItem
     name="require-props-default-doc"
-    description="Props(interface) のオプショナルなプロパティに '@default' JSDoc を書くことを強制します"
+    description="Props (interface) のオプショナルなプロパティに '@default' JSDoc を書くことを強制します"
     link="/ja/rules/require-props-default-doc"
     :isRecommended="false"
     :isFixable="false"

--- a/docs/ja/rules/no-unused-props.md
+++ b/docs/ja/rules/no-unused-props.md
@@ -4,25 +4,18 @@ titleTemplate: ":title"
 ---
 
 <script setup>
-import RecommendedItem from '../../components/RecommendedItem.vue'
-import FixableItem from '../../components/FixableItem.vue'
-import Playground from '../../components/Playground.vue'
+import NotRecommendedItem from '../../components/NotRecommendedItem.vue'
+import NextRecommendedItem from '../../components/NextRecommendedItem.vue'
 </script>
 
 # no-unused-props
 
-<RecommendedItem japanese />
+<NotRecommendedItem japanese />
+<NextRecommendedItem japanese version="v4.0.0" />
 
-このルールは、CDK Construct のpropsインターフェースで定義されたすべてのプロパティが、コンストラクタ内で実際に使用されることを強制します。
+このルールは、Construct の Props (interface) で定義されたすべてのプロパティが、Construct のコンストラクタ内で実際に使用されることを強制します。
 
-CDK Construct の開発では、複数のプロパティを持つpropsインターフェースを定義することが一般的ですが、開発者がコンストラクタの実装でこれらのプロパティの一部を使用するのを忘れる場合があります。これは以下のような問題を引き起こします：
-
-- **デッドコード**: 目的がない未使用のpropsプロパティ
-- **メンテナンス負荷**: 使用されているように見えて実際には無視されているプロパティ
-- **開発者の混乱**: どのプロパティが実際に必須でオプションなのかが不明
-- **実行時の非効率性**: 渡されているが使用されないプロパティ
-
-このルールは、開発プロセスの早い段階でこれらの問題を発見するのに役立ちます。
+CDK Construct の開発では、複数のプロパティを持つ Props (interface) を定義することが一般的ですが、開発者がコンストラクタの実装でこれらのプロパティの一部を使用するのを忘れる場合があり、これはデッドコードを引き起こします
 
 (このルールは `Construct` を継承するクラスにのみ適用されます。)
 
@@ -56,95 +49,12 @@ interface MyConstructProps {
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: MyConstructProps) {
     super(scope, id);
-    
+
     // ✅ すべてのpropsプロパティが使用されています
     new Bucket(this, "MyBucket", {
       bucketName: props.bucketName,
-      versioned: props.enableVersioning
+      versioned: props.enableVersioning,
     });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    // ✅ 分割代入がサポートされています
-    const { bucketName, enableVersioning } = props;
-    new Bucket(this, "MyBucket", {
-      bucketName,
-      versioned: enableVersioning
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  private props: MyConstructProps;
-  
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    // ✅ this.propsパターンがサポートされています
-    this.props = props;
-    new Bucket(this, "MyBucket", {
-      bucketName: this.props.bucketName,
-      versioned: this.props.enableVersioning
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string, { bucketName, enableVersioning }: MyConstructProps) {
-    super(scope, id);
-    
-    // ✅ インライン分割代入がサポートされています
-    new Bucket(this, "MyBucket", {
-      bucketName,
-      versioned: enableVersioning
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-    
-    // ✅ propsパラメータがない場合は検証されません
-    new Bucket(this, "MyBucket");
   }
 }
 ```
@@ -164,65 +74,11 @@ interface MyConstructProps {
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: MyConstructProps) {
     super(scope, id);
-    
+
     new Bucket(this, "MyBucket", {
       bucketName: props.bucketName,
-      versioned: props.enableVersioning
-      // unusedPropは一度もアクセスされていません
+      versioned: props.enableVersioning,
     });
   }
 }
 ```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    // ❌ プロパティが定義されているのに使用されていません
-    new Bucket(this, "MyBucket", {
-      bucketName: "hardcoded-name",
-      versioned: true
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-  readonly config: {
-    readonly timeout: number;
-  };
-}
-
-export class MyConstruct extends Construct {
-  private props: MyConstructProps;
-  
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    this.props = props;
-    
-    // ❌ 一部のプロパティのみが使用されています
-    new Bucket(this, "MyBucket", {
-      bucketName: this.props.bucketName
-      // enableVersioningとconfigは使用されていません
-    });
-  }
-}
-```
-
-<Playground link="https://eslint-online-playground.netlify.app/#eNqVVdty2jAQ/ZWNT9CpbSbc0gsD5dAD0AFuVQ+KtE7UyJJGkptmMjly4xPg5/gSVpJjO20Cl8TWvn379HbXuyJ4bnQjl9WDN7qYFzuqCaEFN62VCtwXG6TRnhZzkiIxFphbQohHtPj4bfZmNqPF5SGo5CJG7vrQW1rcD7HWiE7BIfEzPCHJs+BX8EZ1sWaGLTotUMYE54OTPFUProPh2BkTriUCY5Z3vM/Y4++e6uIyntXalG0X2EJBaZ2x4MK2NE169qXUAVzDOFTBoxGytcYFsiM37zu+hkD2pHGmRXa28SUX6xKvWsdnj5e8oppqeEopAxH5tP2A5qFOHm5jjexhXZM/v34QB0wYrbaklyLBE+aAMKXMBkREDpBHpqTIOuYHQalkZvv9k0T+nkRqFJnq0WIU44lfmU4JsoCBN+ZLfYYcbaO61/p9JT1x2B8iDDJpEwizFoUFM60Qz0ELqZdkI8NqlHHSm5vhOdmyeKkA2wZeYU41DOnYmRw5NOVdfq0fsBqmDt0T0EgN2AZMH1vYgzPrNCH4Y9qwteC5kzaUOTAF4xDcqm6Jfh/RpuGwKXA8GKiFdSr9D5pe3cW7H93SVw5w/1p0EkSa4qrCmfwPpl/PBrfWp/27uKgvMG1cQNw3hMfgIPwUW4bHxbl/fYUdsIyv2RKefSCiMXnZDlud0mgh4PEabGTSHKfx+Mvx0s3IoFgAP/0WjLgzgBNG/wN3JjjZ4zMIdCdvb7rGCEgGxfnc/wVfdM8z" />

--- a/docs/ja/rules/no-unused-props.md
+++ b/docs/ja/rules/no-unused-props.md
@@ -116,6 +116,28 @@ export class MyConstruct extends Construct {
 
 ```ts
 import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, { bucketName, enableVersioning }: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ インライン分割代入がサポートされています
+    new Bucket(this, "MyBucket", {
+      bucketName,
+      versioned: enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
 
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {

--- a/docs/ja/rules/no-unused-props.md
+++ b/docs/ja/rules/no-unused-props.md
@@ -1,0 +1,206 @@
+---
+title: eslint-cdk-plugin - no-unused-props
+titleTemplate: ":title"
+---
+
+<script setup>
+import RecommendedItem from '../../components/RecommendedItem.vue'
+import FixableItem from '../../components/FixableItem.vue'
+import Playground from '../../components/Playground.vue'
+</script>
+
+# no-unused-props
+
+<RecommendedItem japanese />
+
+このルールは、CDK Construct のpropsインターフェースで定義されたすべてのプロパティが、コンストラクタ内で実際に使用されることを強制します。
+
+CDK Construct の開発では、複数のプロパティを持つpropsインターフェースを定義することが一般的ですが、開発者がコンストラクタの実装でこれらのプロパティの一部を使用するのを忘れる場合があります。これは以下のような問題を引き起こします：
+
+- **デッドコード**: 目的がない未使用のpropsプロパティ
+- **メンテナンス負荷**: 使用されているように見えて実際には無視されているプロパティ
+- **開発者の混乱**: どのプロパティが実際に必須でオプションなのかが不明
+- **実行時の非効率性**: 渡されているが使用されないプロパティ
+
+このルールは、開発プロセスの早い段階でこれらの問題を発見するのに役立ちます。
+
+(このルールは `Construct` を継承するクラスにのみ適用されます。)
+
+---
+
+#### 🔧 使用方法
+
+```js
+// eslint.config.mjs
+export default defineConfig([
+  {
+    // ... some configs
+    rules: {
+      "cdk/no-unused-props": "error",
+    },
+  },
+]);
+```
+
+#### ✅ 正しい例
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ すべてのpropsプロパティが使用されています
+    new Bucket(this, "MyBucket", {
+      bucketName: props.bucketName,
+      versioned: props.enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ 分割代入がサポートされています
+    const { bucketName, enableVersioning } = props;
+    new Bucket(this, "MyBucket", {
+      bucketName,
+      versioned: enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  private props: MyConstructProps;
+  
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ this.propsパターンがサポートされています
+    this.props = props;
+    new Bucket(this, "MyBucket", {
+      bucketName: this.props.bucketName,
+      versioned: this.props.enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    
+    // ✅ propsパラメータがない場合は検証されません
+    new Bucket(this, "MyBucket");
+  }
+}
+```
+
+#### ❌ 不正な例
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+  readonly unusedProp: string; // ❌ このプロパティは使用されていません
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    new Bucket(this, "MyBucket", {
+      bucketName: props.bucketName,
+      versioned: props.enableVersioning
+      // unusedPropは一度もアクセスされていません
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ❌ プロパティが定義されているのに使用されていません
+    new Bucket(this, "MyBucket", {
+      bucketName: "hardcoded-name",
+      versioned: true
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+  readonly config: {
+    readonly timeout: number;
+  };
+}
+
+export class MyConstruct extends Construct {
+  private props: MyConstructProps;
+  
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    this.props = props;
+    
+    // ❌ 一部のプロパティのみが使用されています
+    new Bucket(this, "MyBucket", {
+      bucketName: this.props.bucketName
+      // enableVersioningとconfigは使用されていません
+    });
+  }
+}
+```
+
+<Playground link="https://eslint-online-playground.netlify.app/#eNqVVdty2jAQ/ZWNT9CpbSbc0gsD5dAD0AFuVQ+KtE7UyJJGkptmMjly4xPg5/gSVpJjO20Cl8TWvn379HbXuyJ4bnQjl9WDN7qYFzuqCaEFN62VCtwXG6TRnhZzkiIxFphbQohHtPj4bfZmNqPF5SGo5CJG7vrQW1rcD7HWiE7BIfEzPCHJs+BX8EZ1sWaGLTotUMYE54OTPFUProPh2BkTriUCY5Z3vM/Y4++e6uIyntXalG0X2EJBaZ2x4MK2NE169qXUAVzDOFTBoxGytcYFsiM37zu+hkD2pHGmRXa28SUX6xKvWsdnj5e8oppqeEopAxH5tP2A5qFOHm5jjexhXZM/v34QB0wYrbaklyLBE+aAMKXMBkREDpBHpqTIOuYHQalkZvv9k0T+nkRqFJnq0WIU44lfmU4JsoCBN+ZLfYYcbaO61/p9JT1x2B8iDDJpEwizFoUFM60Qz0ELqZdkI8NqlHHSm5vhOdmyeKkA2wZeYU41DOnYmRw5NOVdfq0fsBqmDt0T0EgN2AZMH1vYgzPrNCH4Y9qwteC5kzaUOTAF4xDcqm6Jfh/RpuGwKXA8GKiFdSr9D5pe3cW7H93SVw5w/1p0EkSa4qrCmfwPpl/PBrfWp/27uKgvMG1cQNw3hMfgIPwUW4bHxbl/fYUdsIyv2RKefSCiMXnZDlud0mgh4PEabGTSHKfx+Mvx0s3IoFgAP/0WjLgzgBNG/wN3JjjZ4zMIdCdvb7rGCEgGxfnc/wVfdM8z" />

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -119,7 +119,7 @@ We currently support the following rules:
   />
   <RuleItem
     name="no-mutable-property-of-props-interface"
-    description="Enforces that properties of Props(interface) are specified with readonly."
+    description="Enforces that properties of Props (interface) are specified with readonly."
     link="/rules/no-mutable-property-of-props-interface"
     :isRecommended="true"
     :isFixable="true"
@@ -140,7 +140,7 @@ We currently support the following rules:
   />
   <RuleItem
     name="no-unused-props"
-    description="Enforces that all properties defined in CDK Construct props interfaces are used within the constructor."
+    description="Enforces that all properties defined in Construct Props (interface) are used within the constructor."
     link="/rules/no-unused-props"
     :isRecommended="false"
     :isFixable="false"
@@ -161,7 +161,7 @@ We currently support the following rules:
   />
   <RuleItem
     name="props-name-convention"
-    description="Enforces that Props(interface) names follow the ${ConstructName}Props format."
+    description="Enforces that Props (interface) names follow the ${ConstructName}Props format."
     link="/rules/props-name-convention"
     :isRecommended="false"
     :isFixable="false"
@@ -182,7 +182,7 @@ We currently support the following rules:
   />
   <RuleItem
     name="require-props-default-doc"
-    description="Requires '@default' JSDoc for optional properties of Props(interface)."
+    description="Requires '@default' JSDoc for optional properties of Props (interface)."
     link="/rules/require-props-default-doc"
     :isRecommended="false"
     :isFixable="false"

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -139,6 +139,13 @@ We currently support the following rules:
     :isFixable="false"
   />
   <RuleItem
+    name="no-unused-props"
+    description="Enforces that all properties defined in CDK Construct props interfaces are used within the constructor."
+    link="/rules/no-unused-props"
+    :isRecommended="true"
+    :isFixable="false"
+  />
+  <RuleItem
     name="no-variable-construct-id"
     description="Disallows using variables for Construct IDs."
     link="/rules/no-variable-construct-id"

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -142,7 +142,7 @@ We currently support the following rules:
     name="no-unused-props"
     description="Enforces that all properties defined in CDK Construct props interfaces are used within the constructor."
     link="/rules/no-unused-props"
-    :isRecommended="true"
+    :isRecommended="false"
     :isFixable="false"
   />
   <RuleItem

--- a/docs/rules/no-unused-props.md
+++ b/docs/rules/no-unused-props.md
@@ -4,25 +4,18 @@ titleTemplate: ":title"
 ---
 
 <script setup>
-import RecommendedItem from '../components/RecommendedItem.vue'
-import FixableItem from '../components/FixableItem.vue'
-import Playground from '../components/Playground.vue'
+import NotRecommendedItem from '../components/NotRecommendedItem.vue'
+import NextRecommendedItem from '../components/NextRecommendedItem.vue'
 </script>
 
 # no-unused-props
 
-<RecommendedItem />
+<NotRecommendedItem />
+<NextRecommendedItem version="v4.0.0" />
 
 This rule enforces that all properties defined in CDK Construct props interfaces are actually used within the constructor.
 
-When developing CDK Constructs, it's common to define props interfaces with multiple properties, but developers may forget to use some of these properties in the constructor implementation. This leads to:
-
-- **Dead code**: Unused properties in props interfaces that serve no purpose
-- **Maintenance burden**: Properties that appear to be used but are actually ignored  
-- **Developer confusion**: Unclear which properties are actually required vs optional
-- **Runtime inefficiency**: Properties being passed but never utilized
-
-This rule helps catch these issues early in the development process.
+When developing CDK Constructs, it's common to define props interfaces with multiple properties, but developers may forget to use some of these properties in the constructor implementation. This leads to dead code.
 
 (This rule applies only to classes that extend `Construct`.)
 
@@ -56,95 +49,12 @@ interface MyConstructProps {
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: MyConstructProps) {
     super(scope, id);
-    
+
     // ✅ All props properties are used
     new Bucket(this, "MyBucket", {
       bucketName: props.bucketName,
-      versioned: props.enableVersioning
+      versioned: props.enableVersioning,
     });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    // ✅ Destructuring is supported
-    const { bucketName, enableVersioning } = props;
-    new Bucket(this, "MyBucket", {
-      bucketName,
-      versioned: enableVersioning
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  private props: MyConstructProps;
-  
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    // ✅ this.props pattern is supported
-    this.props = props;
-    new Bucket(this, "MyBucket", {
-      bucketName: this.props.bucketName,
-      versioned: this.props.enableVersioning
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string, { bucketName, enableVersioning }: MyConstructProps) {
-    super(scope, id);
-    
-    // ✅ Inline destructuring is supported
-    new Bucket(this, "MyBucket", {
-      bucketName,
-      versioned: enableVersioning
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-    
-    // ✅ No props parameter means no validation
-    new Bucket(this, "MyBucket");
   }
 }
 ```
@@ -164,65 +74,11 @@ interface MyConstructProps {
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: MyConstructProps) {
     super(scope, id);
-    
+
     new Bucket(this, "MyBucket", {
       bucketName: props.bucketName,
-      versioned: props.enableVersioning
-      // unusedProp is never accessed
+      versioned: props.enableVersioning,
     });
   }
 }
 ```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-}
-
-export class MyConstruct extends Construct {
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    // ❌ Properties are defined but not used
-    new Bucket(this, "MyBucket", {
-      bucketName: "hardcoded-name",
-      versioned: true
-    });
-  }
-}
-```
-
-```ts
-import { Construct } from "constructs";
-import { Bucket } from "aws-cdk-lib/aws-s3";
-
-interface MyConstructProps {
-  readonly bucketName: string;
-  readonly enableVersioning: boolean;
-  readonly config: {
-    readonly timeout: number;
-  };
-}
-
-export class MyConstruct extends Construct {
-  private props: MyConstructProps;
-  
-  constructor(scope: Construct, id: string, props: MyConstructProps) {
-    super(scope, id);
-    
-    this.props = props;
-    
-    // ❌ Only some properties are used
-    new Bucket(this, "MyBucket", {
-      bucketName: this.props.bucketName
-      // enableVersioning and config are never used
-    });
-  }
-}
-```
-
-<Playground link="https://eslint-online-playground.netlify.app/#eNqVVdty2jAQ/ZWNT9CpbSbc0gsD5dAD0AFuVQ+KtE7UyJJGkptmMjly4xPg5/gSVpJjO20Cl8TWvn379HbXuyJ4bnQjl9WDN7qYFzuqCaEFN62VCtwXG6TRnhZzkiIxFphbQohHtPj4bfZmNqPF5SGo5CJG7vrQW1rcD7HWiE7BIfEzPCHJs+BX8EZ1sWaGLTotUMYE54OTPFUProPh2BkTriUCY5Z3vM/Y4++e6uIyntXalG0X2EJBaZ2x4MK2NE169qXUAVzDOFTBoxGytcYFsiM37zu+hkD2pHGmRXa28SUX6xKvWsdnj5e8oppqeEopAxH5tP2A5qFOHm5jjexhXZM/v34QB0wYrbaklyLBE+aAMKXMBkREDpBHpqTIOuYHQalkZvv9k0T+nkRqFJnq0WIU44lfmU4JsoCBN+ZLfYYcbaO61/p9JT1x2B8iDDJpEwizFoUFM60Qz0ELqZdkI8NqlHHSm5vhOdmyeKkA2wZeYU41DOnYmRw5NOVdfq0fsBqmDt0T0EgN2AZMH1vYgzPrNCH4Y9qwteC5kzaUOTAF4xDcqm6Jfh/RpuGwKXA8GKiFdSr9D5pe3cW7H93SVw5w/1p0EkSa4qrCmfwPpl/PBrfWp/27uKgvMG1cQNw3hMfgIPwUW4bHxbl/fYUdsIyv2RKefSCiMXnZDlud0mgh4PEabGTSHKfx+Mvx0s3IoFgAP/0WjLgzgBNG/wN3JjjZ4zMIdCdvb7rGCEgGxfnc/wVfdM8z" />

--- a/docs/rules/no-unused-props.md
+++ b/docs/rules/no-unused-props.md
@@ -13,9 +13,9 @@ import NextRecommendedItem from '../components/NextRecommendedItem.vue'
 <NotRecommendedItem />
 <NextRecommendedItem version="v4.0.0" />
 
-This rule enforces that all properties defined in CDK Construct props interfaces are actually used within the constructor.
+This rule enforces that all properties defined in CDK Construct props interface are actually used within the constructor.
 
-When developing CDK Constructs, it's common to define props interfaces with multiple properties, but developers may forget to use some of these properties in the constructor implementation. This leads to dead code.
+When developing CDK Constructs, it's common to define props interface with multiple properties, but developers may forget to use some of these properties in the constructor implementation. This leads to dead code.
 
 (This rule applies only to classes that extend `Construct`.)
 

--- a/docs/rules/no-unused-props.md
+++ b/docs/rules/no-unused-props.md
@@ -116,6 +116,28 @@ export class MyConstruct extends Construct {
 
 ```ts
 import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, { bucketName, enableVersioning }: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ Inline destructuring is supported
+    new Bucket(this, "MyBucket", {
+      bucketName,
+      versioned: enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
 
 export class MyConstruct extends Construct {
   constructor(scope: Construct, id: string) {

--- a/docs/rules/no-unused-props.md
+++ b/docs/rules/no-unused-props.md
@@ -1,0 +1,206 @@
+---
+title: eslint-cdk-plugin - no-unused-props
+titleTemplate: ":title"
+---
+
+<script setup>
+import RecommendedItem from '../components/RecommendedItem.vue'
+import FixableItem from '../components/FixableItem.vue'
+import Playground from '../components/Playground.vue'
+</script>
+
+# no-unused-props
+
+<RecommendedItem />
+
+This rule enforces that all properties defined in CDK Construct props interfaces are actually used within the constructor.
+
+When developing CDK Constructs, it's common to define props interfaces with multiple properties, but developers may forget to use some of these properties in the constructor implementation. This leads to:
+
+- **Dead code**: Unused properties in props interfaces that serve no purpose
+- **Maintenance burden**: Properties that appear to be used but are actually ignored  
+- **Developer confusion**: Unclear which properties are actually required vs optional
+- **Runtime inefficiency**: Properties being passed but never utilized
+
+This rule helps catch these issues early in the development process.
+
+(This rule applies only to classes that extend `Construct`.)
+
+---
+
+#### 🔧 How to use
+
+```js
+// eslint.config.mjs
+export default defineConfig([
+  {
+    // ... some configs
+    rules: {
+      "cdk/no-unused-props": "error",
+    },
+  },
+]);
+```
+
+#### ✅ Correct Example
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ All props properties are used
+    new Bucket(this, "MyBucket", {
+      bucketName: props.bucketName,
+      versioned: props.enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ Destructuring is supported
+    const { bucketName, enableVersioning } = props;
+    new Bucket(this, "MyBucket", {
+      bucketName,
+      versioned: enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  private props: MyConstructProps;
+  
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ✅ this.props pattern is supported
+    this.props = props;
+    new Bucket(this, "MyBucket", {
+      bucketName: this.props.bucketName,
+      versioned: this.props.enableVersioning
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    
+    // ✅ No props parameter means no validation
+    new Bucket(this, "MyBucket");
+  }
+}
+```
+
+#### ❌ Incorrect Example
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+  readonly unusedProp: string; // ❌ This property is never used
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    new Bucket(this, "MyBucket", {
+      bucketName: props.bucketName,
+      versioned: props.enableVersioning
+      // unusedProp is never accessed
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+}
+
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    // ❌ Properties are defined but not used
+    new Bucket(this, "MyBucket", {
+      bucketName: "hardcoded-name",
+      versioned: true
+    });
+  }
+}
+```
+
+```ts
+import { Construct } from "constructs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+interface MyConstructProps {
+  readonly bucketName: string;
+  readonly enableVersioning: boolean;
+  readonly config: {
+    readonly timeout: number;
+  };
+}
+
+export class MyConstruct extends Construct {
+  private props: MyConstructProps;
+  
+  constructor(scope: Construct, id: string, props: MyConstructProps) {
+    super(scope, id);
+    
+    this.props = props;
+    
+    // ❌ Only some properties are used
+    new Bucket(this, "MyBucket", {
+      bucketName: this.props.bucketName
+      // enableVersioning and config are never used
+    });
+  }
+}
+```
+
+<Playground link="https://eslint-online-playground.netlify.app/#eNqVVdty2jAQ/ZWNT9CpbSbc0gsD5dAD0AFuVQ+KtE7UyJJGkptmMjly4xPg5/gSVpJjO20Cl8TWvn379HbXuyJ4bnQjl9WDN7qYFzuqCaEFN62VCtwXG6TRnhZzkiIxFphbQohHtPj4bfZmNqPF5SGo5CJG7vrQW1rcD7HWiE7BIfEzPCHJs+BX8EZ1sWaGLTotUMYE54OTPFUProPh2BkTriUCY5Z3vM/Y4++e6uIyntXalG0X2EJBaZ2x4MK2NE169qXUAVzDOFTBoxGytcYFsiM37zu+hkD2pHGmRXa28SUX6xKvWsdnj5e8oppqeEopAxH5tP2A5qFOHm5jjexhXZM/v34QB0wYrbaklyLBE+aAMKXMBkREDpBHpqTIOuYHQalkZvv9k0T+nkRqFJnq0WIU44lfmU4JsoCBN+ZLfYYcbaO61/p9JT1x2B8iDDJpEwizFoUFM60Qz0ELqZdkI8NqlHHSm5vhOdmyeKkA2wZeYU41DOnYmRw5NOVdfq0fsBqmDt0T0EgN2AZMH1vYgzPrNCH4Y9qwteC5kzaUOTAF4xDcqm6Jfh/RpuGwKXA8GKiFdSr9D5pe3cW7H93SVw5w/1p0EkSa4qrCmfwPpl/PBrfWp/27uKgvMG1cQNw3hMfgIPwUW4bHxbl/fYUdsIyv2RKefSCiMXnZDlud0mgh4PEabGTSHKfx+Mvx0s3IoFgAP/0WjLgzgBNG/wN3JjjZ4zMIdCdvb7rGCEgGxfnc/wVfdM8z" />

--- a/src/__tests__/no-unused-props.test.ts
+++ b/src/__tests__/no-unused-props.test.ts
@@ -184,6 +184,47 @@ ruleTester.run("no-unused-props", typedRule, {
       }
       `,
     },
+    // WHEN: Properties are used via destructuring with aliases
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const { bucketName: bn, enableVersioning: ev } = props;
+          new Bucket(this, "MyBucket", {
+            bucketName: bn,
+            versioned: ev
+          });
+        }
+      }
+      `,
+    },
+    // WHEN: Inline destructuring in constructor parameters (all properties used)
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, { bucketName, enableVersioning }: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName,
+            versioned: enableVersioning
+          });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: Some properties are unused
@@ -320,6 +361,51 @@ ruleTester.run("no-unused-props", typedRule, {
           new Bucket(this, "MyBucket", {
             bucketName: this.props.bucketName,
             versioned: this.props.enableVersioning
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp" }],
+    },
+    // WHEN: Alias destructuring with some properties unused
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const { bucketName: bn, enableVersioning: ev } = props;
+          new Bucket(this, "MyBucket", {
+            bucketName: bn,
+            versioned: ev
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp" }],
+    },
+    // WHEN: Inline destructuring with some properties unused
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, { bucketName, enableVersioning }: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName,
+            versioned: enableVersioning
           });
         }
       }

--- a/src/__tests__/no-unused-props.test.ts
+++ b/src/__tests__/no-unused-props.test.ts
@@ -27,6 +27,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -47,6 +54,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -68,6 +82,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -92,6 +113,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -118,6 +146,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning?: boolean;
@@ -138,7 +173,12 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
-      
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+
       export class MyConstruct extends Construct {
         constructor(scope: Construct, id: string) {
           super(scope, id);
@@ -166,6 +206,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         config: {
           bucketName: string;
@@ -188,6 +235,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -209,6 +263,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -229,6 +290,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName?: string;
         enableVersioning?: boolean;
@@ -251,6 +319,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -273,6 +348,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -288,15 +370,19 @@ ruleTester.run("no-unused-props", typedRule, {
         }
       }
       `,
-      errors: [
-        { messageId: "unusedProp" },
-        { messageId: "unusedProp" }
-      ],
+      errors: [{ messageId: "unusedProp" }, { messageId: "unusedProp" }],
     },
     // WHEN: Props parameter is not referenced at all
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -309,15 +395,19 @@ ruleTester.run("no-unused-props", typedRule, {
         }
       }
       `,
-      errors: [
-        { messageId: "unusedProp" },
-        { messageId: "unusedProp" }
-      ],
+      errors: [{ messageId: "unusedProp" }, { messageId: "unusedProp" }],
     },
     // WHEN: Only some properties are used via destructuring
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -341,6 +431,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -358,13 +455,20 @@ ruleTester.run("no-unused-props", typedRule, {
       errors: [
         { messageId: "unusedProp" },
         { messageId: "unusedProp" },
-        { messageId: "unusedProp" }
+        { messageId: "unusedProp" },
       ],
     },
     // WHEN: Props is assigned to private variable but some properties are unused
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -391,6 +495,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;
@@ -414,6 +525,13 @@ ruleTester.run("no-unused-props", typedRule, {
     {
       code: `
       class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: { bucketName: string; versioned: boolean }) {
+          super(scope, id);
+          console.log(props.bucketName, props.versioned);
+        }
+      }
+
       interface MyConstructProps {
         bucketName: string;
         enableVersioning: boolean;

--- a/src/__tests__/no-unused-props.test.ts
+++ b/src/__tests__/no-unused-props.test.ts
@@ -225,6 +225,26 @@ ruleTester.run("no-unused-props", typedRule, {
       }
       `,
     },
+    // WHEN: Properties are used via optional chaining
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName?: string;
+        enableVersioning?: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName: props?.bucketName || "default",
+            versioned: props?.enableVersioning || false
+          });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: Some properties are unused

--- a/src/__tests__/no-unused-props.test.ts
+++ b/src/__tests__/no-unused-props.test.ts
@@ -1,0 +1,330 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+
+import { noUnusedProps } from "../rules/no-unused-props";
+
+const typedRule = noUnusedProps as ESLintUtils.RuleModule<
+  "unusedProp",
+  [],
+  {
+    ClassDeclaration(node: TSESTree.ClassDeclaration): void;
+  }
+>;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["*.ts*"],
+      },
+    },
+  },
+});
+
+ruleTester.run("no-unused-props", typedRule, {
+  valid: [
+    // WHEN: All properties are used directly
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName: props.bucketName,
+            versioned: props.enableVersioning
+          });
+        }
+      }
+      `,
+    },
+    // WHEN: Properties are used via destructuring
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const { bucketName, enableVersioning } = props;
+          new Bucket(this, "MyBucket", {
+            bucketName,
+            versioned: enableVersioning
+          });
+        }
+      }
+      `,
+    },
+    // WHEN: Props is assigned to private variable and all properties are used
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        private props: MyConstructProps;
+        
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.props = props;
+          
+          new Bucket(this, "MyBucket", {
+            bucketName: this.props.bucketName,
+            versioned: this.props.enableVersioning
+          });
+        }
+      }
+      `,
+    },
+    // WHEN: Individual properties are assigned to instance variables
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        private bucketName: string;
+        private enableVersioning: boolean;
+        
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.bucketName = props.bucketName;
+          this.enableVersioning = props.enableVersioning;
+          
+          new Bucket(this, "MyBucket", {
+            bucketName: this.bucketName,
+            versioned: this.enableVersioning
+          });
+        }
+      }
+      `,
+    },
+    // WHEN: Optional properties are used conditionally
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning?: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName: props.bucketName,
+            versioned: props.enableVersioning || false
+          });
+        }
+      }
+      `,
+    },
+    // WHEN: Constructor has no props parameter
+    {
+      code: `
+      class Construct {}
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new Bucket(this, "MyBucket");
+        }
+      }
+      `,
+    },
+    // WHEN: Class does not extend Construct
+    {
+      code: `
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyClass {
+        constructor(props: MyConstructProps) {
+          // This should not be checked as it's not a Construct
+        }
+      }
+      `,
+    },
+    // WHEN: Props is used in nested object access
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        config: {
+          bucketName: string;
+          enableVersioning: boolean;
+        };
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName: props.config.bucketName,
+            versioned: props.config.enableVersioning
+          });
+        }
+      }
+      `,
+    },
+  ],
+  invalid: [
+    // WHEN: Some properties are unused
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName: props.bucketName,
+            versioned: props.enableVersioning
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp" }],
+    },
+    // WHEN: All properties are unused but props parameter exists
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket", {
+            bucketName: "hardcoded-name",
+            versioned: true
+          });
+        }
+      }
+      `,
+      errors: [
+        { messageId: "unusedProp" },
+        { messageId: "unusedProp" }
+      ],
+    },
+    // WHEN: Props parameter is not referenced at all
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "MyBucket");
+        }
+      }
+      `,
+      errors: [
+        { messageId: "unusedProp" },
+        { messageId: "unusedProp" }
+      ],
+    },
+    // WHEN: Only some properties are used via destructuring
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const { bucketName, enableVersioning } = props;
+          new Bucket(this, "MyBucket", {
+            bucketName,
+            versioned: enableVersioning
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp" }],
+    },
+    // WHEN: Props is accessed but not all properties are used
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+      
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props); // props is referenced but properties not used
+          new Bucket(this, "MyBucket");
+        }
+      }
+      `,
+      errors: [
+        { messageId: "unusedProp" },
+        { messageId: "unusedProp" },
+        { messageId: "unusedProp" }
+      ],
+    },
+    // WHEN: Props is assigned to private variable but some properties are unused
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+      
+      export class MyConstruct extends Construct {
+        private props: MyConstructProps;
+        
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.props = props;
+          
+          new Bucket(this, "MyBucket", {
+            bucketName: this.props.bucketName,
+            versioned: this.props.enableVersioning
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp" }],
+    },
+  ],
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,8 @@ const recommended = createFlatConfig({
     "error",
     { disallowContainingParentName: false },
   ],
-  "cdk/no-unused-props": "error",
+  // TODO: Enable this rule at v4.0.0
+  // "cdk/no-unused-props": "error",
   "cdk/no-variable-construct-id": "error",
   "cdk/pascal-case-construct-id": "error",
   "cdk/require-passing-this": ["error", { allowNonThisAndDisallowScope: true }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { noImportPrivate } from "./rules/no-import-private";
 import { noMutablePropertyOfPropsInterface } from "./rules/no-mutable-property-of-props-interface";
 import { noMutablePublicPropertyOfConstruct } from "./rules/no-mutable-public-property-of-construct";
 import { noParentNameConstructIdMatch } from "./rules/no-parent-name-construct-id-match";
+import { noUnusedProps } from "./rules/no-unused-props";
 import { noVariableConstructId } from "./rules/no-variable-construct-id";
 import { pascalCaseConstructId } from "./rules/pascal-case-construct-id";
 import { propsNameConvention } from "./rules/props-name-convention";
@@ -27,6 +28,7 @@ const rules = {
   "no-mutable-property-of-props-interface": noMutablePropertyOfPropsInterface,
   "no-mutable-public-property-of-construct": noMutablePublicPropertyOfConstruct,
   "no-parent-name-construct-id-match": noParentNameConstructIdMatch,
+  "no-unused-props": noUnusedProps,
   "no-variable-construct-id": noVariableConstructId,
   "pascal-case-construct-id": pascalCaseConstructId,
   "props-name-convention": propsNameConvention,
@@ -66,6 +68,7 @@ const recommended = createFlatConfig({
     "error",
     { disallowContainingParentName: false },
   ],
+  "cdk/no-unused-props": "error",
   "cdk/no-variable-construct-id": "error",
   "cdk/pascal-case-construct-id": "error",
   "cdk/require-passing-this": ["error", { allowNonThisAndDisallowScope: true }],
@@ -83,6 +86,7 @@ const strict = createFlatConfig({
     "error",
     { disallowContainingParentName: true },
   ],
+  "cdk/no-unused-props": "error",
   "cdk/no-variable-construct-id": "error",
   "cdk/pascal-case-construct-id": "error",
   "cdk/props-name-convention": "error",

--- a/src/rules/construct-constructor-property.ts
+++ b/src/rules/construct-constructor-property.ts
@@ -7,6 +7,7 @@ import {
 } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils/createRule";
+import { getConstructor } from "../utils/getConstructor";
 import { isConstructType } from "../utils/typeCheck";
 
 type Context = TSESLint.RuleContext<
@@ -47,14 +48,7 @@ export const constructConstructorProperty = createRule({
         const type = parserServices.getTypeAtLocation(node);
         if (!isConstructType(type)) return;
 
-        // NOTE: Find the constructor method
-        const constructor = node.body.body.find(
-          (member): member is TSESTree.MethodDefinition =>
-            member.type === AST_NODE_TYPES.MethodDefinition &&
-            member.kind === "constructor"
-        );
-
-        // NOTE: Skip if there's no constructor
+        const constructor = getConstructor(node);
         if (!constructor) return;
 
         validateConstructorProperty(constructor, context, parserServices);

--- a/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/src/rules/no-construct-in-public-property-of-construct.ts
@@ -8,6 +8,7 @@ import {
 
 import { SYMBOL_FLAGS } from "../constants/tsInternalFlags";
 import { createRule } from "../utils/createRule";
+import { getConstructor } from "../utils/getConstructor";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
 type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
@@ -42,11 +43,7 @@ export const noConstructInPublicPropertyOfConstruct = createRule({
         validatePublicPropertyOfConstruct(node, context, parserServices);
 
         // NOTE: Check constructor parameter properties
-        const constructor = node.body.body.find(
-          (member): member is TSESTree.MethodDefinition =>
-            member.type === AST_NODE_TYPES.MethodDefinition &&
-            member.kind === "constructor"
-        );
+        const constructor = getConstructor(node);
         if (
           !constructor ||
           constructor.value.type !== AST_NODE_TYPES.FunctionExpression

--- a/src/rules/no-construct-stack-suffix.ts
+++ b/src/rules/no-construct-stack-suffix.ts
@@ -7,7 +7,7 @@ import {
 
 import { toPascalCase } from "../utils/convertString";
 import { createRule } from "../utils/createRule";
-import { getConstructorPropertyNames } from "../utils/parseType";
+import { getConstructorPropertyNames } from "../utils/getPropertyNames";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
 const SUFFIX_TYPE = {

--- a/src/rules/no-unused-props.ts
+++ b/src/rules/no-unused-props.ts
@@ -108,8 +108,6 @@ const analyzePropsUsage = (
     
     const tracker = new PropsUsageTracker(propProperties);
     
-    if (!tracker.hasProperties()) return;
-    
     // Check if constructor has a body
     if (!constructor.value.body) return;
     

--- a/src/rules/no-unused-props.ts
+++ b/src/rules/no-unused-props.ts
@@ -1,0 +1,322 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  ParserServicesWithTypeInformation,
+  TSESLint,
+  TSESTree,
+} from "@typescript-eslint/utils";
+import { Type, TypeChecker } from "typescript";
+
+import { createRule } from "../utils/createRule";
+import { isConstructType } from "../utils/typeCheck";
+
+type Context = TSESLint.RuleContext<"unusedProp", []>;
+
+/**
+ * Tracks usage of props properties
+ */
+class PropsUsageTracker {
+  private readonly propUsages = new Map<string, boolean>();
+
+  constructor(propertyNames: string[]) {
+    for (const name of propertyNames) {
+      this.propUsages.set(name, false);
+    }
+  }
+
+  markAsUsed(propertyName: string): void {
+    if (this.propUsages.has(propertyName)) {
+      this.propUsages.set(propertyName, true);
+    }
+  }
+
+  getUnusedProperties(): string[] {
+    return Array.from(this.propUsages.entries())
+      .filter(([, used]) => !used)
+      .map(([name]) => name);
+  }
+
+  hasProperties(): boolean {
+    return !!this.propUsages.size;
+  }
+}
+
+/**
+ * Enforces that all properties defined in props type are used within the constructor
+ * @param context - The rule context provided by ESLint
+ * @returns An object containing the AST visitor functions
+ */
+export const noUnusedProps = createRule({
+  name: "no-unused-props",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforces that all properties defined in props type are used within the constructor",
+    },
+    messages: {
+      unusedProp: "Property '{{propName}}' is defined in props but never used",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const typeChecker = parserServices.program.getTypeChecker();
+
+    return {
+      ClassDeclaration(node) {
+        const type = parserServices.getTypeAtLocation(node);
+        if (!isConstructType(type)) return;
+
+        const constructor = node.body.body.find(
+          (member): member is TSESTree.MethodDefinition =>
+            member.type === AST_NODE_TYPES.MethodDefinition &&
+            member.kind === "constructor"
+        );
+        if (!constructor) return;
+
+        analyzePropsUsage(constructor, context, parserServices, typeChecker);
+      },
+    };
+  },
+});
+
+/**
+ * Analyzes props usage in the constructor
+ */
+const analyzePropsUsage = (
+  constructor: TSESTree.MethodDefinition,
+  context: Context,
+  parserServices: ParserServicesWithTypeInformation,
+  typeChecker: TypeChecker
+): void => {
+  const params = constructor.value.params;
+
+  // NOTE: Check if constructor has props parameter (3rd parameter)
+  if (params.length < 3) return;
+
+  const propsParam = params[2];
+  if (propsParam.type !== AST_NODE_TYPES.Identifier) return;
+
+  const propsType = parserServices.getTypeAtLocation(propsParam);
+  const propProperties = getPropsProperties(propsType, typeChecker);
+
+  if (!propProperties.length) return;
+
+  // Initialize usage tracking
+  const tracker = new PropsUsageTracker(propProperties);
+
+  if (!tracker.hasProperties()) return;
+
+  // Check if constructor has a body
+  if (!constructor.value.body) return;
+
+  // Analyze constructor body for props usage
+  analyzeConstructorBody(constructor.value.body, propsParam.name, tracker);
+
+  // Report unused properties
+  for (const propName of tracker.getUnusedProperties()) {
+    context.report({
+      node: propsParam,
+      messageId: "unusedProp",
+      data: {
+        propName,
+      },
+    });
+  }
+};
+
+/**
+ * Extracts property names from props type
+ */
+const getPropsProperties = (
+  propsType: Type,
+  typeChecker: TypeChecker
+): string[] => {
+  // Try to get properties from type checker first (more reliable)
+  const typeProperties = typeChecker.getPropertiesOfType(propsType);
+  if (typeProperties.length) {
+    return typeProperties.reduce<string[]>((acc, prop) => {
+      const name = prop.getName();
+      if (!isInternalProperty(name)) {
+        return [...acc, name];
+      }
+      return acc;
+    }, []);
+  }
+
+  // Fallback: get properties from symbol members
+  const symbol = propsType.getSymbol();
+  if (!symbol?.members) return [];
+
+  return Array.from(symbol.members.keys()).reduce<string[]>((acc, key) => {
+    const name = String(key);
+    if (!isInternalProperty(name)) {
+      return [...acc, name];
+    }
+    return acc;
+  }, []);
+};
+
+/**
+ * Checks if a property is an internal TypeScript property
+ */
+const isInternalProperty = (propertyName: string): boolean => {
+  return (
+    propertyName.startsWith("__") ||
+    propertyName === "constructor" ||
+    propertyName === "prototype"
+  );
+};
+
+/**
+ * Type guard to check if a value is a TSESTree.Node
+ */
+const isESTreeNode = (value: unknown): value is TSESTree.Node => {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "type" in value &&
+    typeof (value as { type: unknown }).type === "string"
+  );
+};
+
+/**
+ * Type guard to check if a value is an array of unknown values
+ */
+const isUnknownArray = (value: unknown): value is unknown[] => {
+  return Array.isArray(value);
+};
+
+/**
+ * Safely gets child nodes from a TSESTree.Node
+ */
+const getChildNodes = (node: TSESTree.Node): TSESTree.Node[] => {
+  const skipKeys = new Set(["parent", "range", "loc"]);
+
+  return Object.entries(node).reduce<TSESTree.Node[]>((acc, [key, value]) => {
+    if (skipKeys.has(key)) return acc;
+
+    if (isESTreeNode(value)) {
+      return [...acc, value];
+    }
+    if (isUnknownArray(value)) {
+      const validNodes = value.filter(isESTreeNode);
+      return [...acc, ...validNodes];
+    }
+    return acc;
+  }, []);
+};
+
+/**
+ * Analyzes constructor body for props usage patterns
+ */
+const analyzeConstructorBody = (
+  body: TSESTree.BlockStatement,
+  propsParamName: string,
+  tracker: PropsUsageTracker
+): void => {
+  const visited = new Set<TSESTree.Node>();
+
+  const visitNode = (node: TSESTree.Node): void => {
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    switch (node.type) {
+      case AST_NODE_TYPES.MemberExpression:
+        handleMemberExpression(node, propsParamName, tracker);
+        break;
+      case AST_NODE_TYPES.VariableDeclarator:
+        handleVariableDeclarator(node, propsParamName, tracker);
+        break;
+      case AST_NODE_TYPES.AssignmentExpression:
+        handleAssignmentExpression(node, propsParamName, tracker);
+        break;
+    }
+
+    // Recursively visit child nodes
+    const children = getChildNodes(node);
+    for (const child of children) {
+      visitNode(child);
+    }
+  };
+
+  visitNode(body);
+};
+
+/**
+ * Handles member expressions like props.propertyName or this.props.propertyName
+ */
+const handleMemberExpression = (
+  node: TSESTree.MemberExpression,
+  propsParamName: string,
+  tracker: PropsUsageTracker
+): void => {
+  // Check for props.propertyName pattern
+  if (
+    node.object.type === AST_NODE_TYPES.Identifier &&
+    node.object.name === propsParamName &&
+    node.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    tracker.markAsUsed(node.property.name);
+    return;
+  }
+
+  // Check for this.props.propertyName pattern
+  if (node.object.type !== AST_NODE_TYPES.MemberExpression) return;
+  if (node.object.object.type !== AST_NODE_TYPES.ThisExpression) return;
+  if (node.object.property.type !== AST_NODE_TYPES.Identifier) return;
+  if (node.object.property.name !== "props") return;
+  if (node.property.type !== AST_NODE_TYPES.Identifier) return;
+
+  tracker.markAsUsed(node.property.name);
+};
+
+/**
+ * Handles variable declarations with destructuring
+ */
+const handleVariableDeclarator = (
+  node: TSESTree.VariableDeclarator,
+  propsParamName: string,
+  tracker: PropsUsageTracker
+): void => {
+  // Check for destructuring assignment: const { prop1, prop2 } = props
+  if (node.id.type !== AST_NODE_TYPES.ObjectPattern) return;
+  if (node.init?.type !== AST_NODE_TYPES.Identifier) return;
+  if (node.init.name !== propsParamName) return;
+
+  const propertyNames = node.id.properties.reduce<string[]>((acc, prop) => {
+    if (
+      prop.type === AST_NODE_TYPES.Property &&
+      prop.key.type === AST_NODE_TYPES.Identifier
+    ) {
+      return [...acc, prop.key.name];
+    }
+    return acc;
+  }, []);
+
+  for (const name of propertyNames) {
+    tracker.markAsUsed(name);
+  }
+};
+
+/**
+ * Handles assignment expressions like this.props = props or this.property = props.property
+ */
+const handleAssignmentExpression = (
+  node: TSESTree.AssignmentExpression,
+  propsParamName: string,
+  tracker: PropsUsageTracker
+): void => {
+  // Check for this.property = props.property pattern
+  if (node.right.type !== AST_NODE_TYPES.MemberExpression) return;
+  if (node.right.object.type !== AST_NODE_TYPES.Identifier) return;
+  if (node.right.object.name !== propsParamName) return;
+  if (node.right.property.type !== AST_NODE_TYPES.Identifier) return;
+
+  tracker.markAsUsed(node.right.property.name);
+
+  // Note: this.props = props pattern doesn't mark all properties as used
+  // because we still need to check which properties are actually accessed later
+};

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -6,7 +6,7 @@ import {
 } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils/createRule";
-import { getConstructorPropertyNames } from "../utils/parseType";
+import { getConstructorPropertyNames } from "../utils/getPropertyNames";
 import { isConstructType } from "../utils/typeCheck";
 
 type Context = TSESLint.RuleContext<"invalidConstructId", []>;

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -7,7 +7,7 @@ import {
 
 import { toPascalCase } from "../utils/convertString";
 import { createRule } from "../utils/createRule";
-import { getConstructorPropertyNames } from "../utils/parseType";
+import { getConstructorPropertyNames } from "../utils/getPropertyNames";
 import { isConstructOrStackType } from "../utils/typeCheck";
 
 const QUOTE_TYPE = {

--- a/src/rules/props-name-convention.ts
+++ b/src/rules/props-name-convention.ts
@@ -1,10 +1,7 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESTree,
-} from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils/createRule";
+import { getConstructor } from "../utils/getConstructor";
 import { isConstructType } from "../utils/typeCheck";
 
 /**
@@ -37,13 +34,10 @@ export const propsNameConvention = createRule({
         if (!isConstructType(type)) return;
 
         // NOTE: check constructor parameter
-        const constructor = node.body.body.find(
-          (member): member is TSESTree.MethodDefinition =>
-            member.type === AST_NODE_TYPES.MethodDefinition &&
-            member.kind === "constructor"
-        );
+        const constructor = getConstructor(node);
+        if (!constructor) return;
 
-        const propsParam = constructor?.value.params?.[2];
+        const propsParam = constructor.value.params?.[2];
         if (propsParam?.type !== AST_NODE_TYPES.Identifier) return;
 
         const typeAnnotation = propsParam.typeAnnotation;

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -5,7 +5,7 @@ import {
 } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils/createRule";
-import { getConstructorPropertyNames } from "../utils/parseType";
+import { getConstructorPropertyNames } from "../utils/getPropertyNames";
 import { isConstructType } from "../utils/typeCheck";
 
 type Options = [

--- a/src/utils/getConstructor.ts
+++ b/src/utils/getConstructor.ts
@@ -1,0 +1,16 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Finds the constructor method in a class declaration
+ * @param node The class declaration
+ * @returns The constructor method definition or undefined if not found
+ */
+export const getConstructor = (
+  node: TSESTree.ClassDeclaration
+): TSESTree.MethodDefinition | undefined => {
+  return node.body.body.find(
+    (member): member is TSESTree.MethodDefinition =>
+      member.type === AST_NODE_TYPES.MethodDefinition &&
+      member.kind === "constructor"
+  );
+};

--- a/src/utils/getPropertyNames.ts
+++ b/src/utils/getPropertyNames.ts
@@ -1,3 +1,4 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 import {
   ClassDeclaration,
   ConstructorDeclaration,
@@ -7,6 +8,26 @@ import {
 } from "typescript";
 
 import { SYNTAX_KIND } from "../constants/tsInternalFlags";
+
+/**
+ * Retrieves the property names from an array of properties.
+ *
+ * @param properties An array of properties to extract names from.
+ * @returns An array of property names.
+ */
+export const getPropertyNames = (
+  properties: (TSESTree.Property | TSESTree.RestElement)[]
+): string[] => {
+  return properties.reduce<string[]>((acc, prop) => {
+    if (
+      prop.type === AST_NODE_TYPES.Property &&
+      prop.key.type === AST_NODE_TYPES.Identifier
+    ) {
+      return [...acc, prop.key.name];
+    }
+    return acc;
+  }, []);
+};
 
 /**
  * Parses type to get the property names of the class constructor.

--- a/src/utils/getPropertyNames.ts
+++ b/src/utils/getPropertyNames.ts
@@ -18,15 +18,14 @@ import { SYNTAX_KIND } from "../constants/tsInternalFlags";
 export const getPropertyNames = (
   properties: (TSESTree.Property | TSESTree.RestElement)[]
 ): string[] => {
-  return properties.reduce<string[]>((acc, prop) => {
-    if (
+  return properties.reduce<string[]>(
+    (acc, prop) =>
       prop.type === AST_NODE_TYPES.Property &&
       prop.key.type === AST_NODE_TYPES.Identifier
-    ) {
-      return [...acc, prop.key.name];
-    }
-    return acc;
-  }, []);
+        ? [...acc, prop.key.name]
+        : acc,
+    []
+  );
 };
 
 /**

--- a/src/utils/propsUsageTracker.ts
+++ b/src/utils/propsUsageTracker.ts
@@ -1,0 +1,188 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { Type } from "typescript";
+
+import { getPropertyNames } from "./getPropertyNames";
+
+export interface IPropsUsageTracker {
+  markAsUsedForMemberExpression(
+    node: TSESTree.MemberExpression,
+    propsParamName: string
+  ): void;
+  markAsUsedForVariableDeclarator(
+    node: TSESTree.VariableDeclarator,
+    propsParamName: string
+  ): void;
+  markAsUsedForAssignmentExpression(
+    node: TSESTree.AssignmentExpression,
+    propsParamName: string
+  ): void;
+  markAsUsedForObjectPattern(node: TSESTree.ObjectPattern): void;
+  getUnusedProperties(): string[];
+}
+
+export const propsUsageTrackerFactory = (
+  propsType: Type
+): IPropsUsageTracker | null => {
+  // ===============================================
+  // Internal utility functions
+  // ===============================================
+  const getPropsPropertyNames = (propsType: Type): string[] => {
+    const typeProperties = propsType.getProperties();
+    if (typeProperties.length) {
+      return typeProperties.reduce<string[]>((acc, prop) => {
+        const name = prop.getName();
+        if (!isInternalProperty(name)) return [...acc, name];
+        return acc;
+      }, []);
+    }
+
+    const symbol = propsType.getSymbol();
+    if (!symbol?.members) return [];
+
+    return Array.from(symbol.members.keys()).reduce<string[]>((acc, key) => {
+      const name = String(key);
+      if (!isInternalProperty(name)) return [...acc, name];
+      return acc;
+    }, []);
+  };
+
+  const isInternalProperty = (propertyName: string): boolean => {
+    return (
+      propertyName.startsWith("_") ||
+      propertyName === "constructor" ||
+      propertyName === "prototype"
+    );
+  };
+
+  const markAsUsed = (propertyName: string): void => {
+    if (propUsages.has(propertyName)) propUsages.set(propertyName, true);
+  };
+
+  // ===============================================
+  // Internal variables
+  // ===============================================
+  const propUsages = new Map<string, boolean>(
+    getPropsPropertyNames(propsType).map((name) => [name, false])
+  );
+
+  // ===============================================
+  // Public functions
+  // ===============================================
+  /**
+   * Returns an array of unused property names.
+   *
+   * @returns An array of unused property names.
+   */
+  const getUnusedProperties = (): string[] => {
+    return Array.from(propUsages.entries()).reduce<string[]>(
+      (acc, [name, used]) => (!used ? [...acc, name] : acc),
+      []
+    );
+  };
+
+  /**
+   * Marks a property as used when it is accessed in a member expression.
+   *
+   * @param node The member expression node.
+   * @param propsParamName The name of the property being tracked.
+   */
+  const markAsUsedForMemberExpression = (
+    node: TSESTree.MemberExpression,
+    propsParamName: string
+  ): void => {
+    // NOTE: Check for props.propertyName or props?.propertyName pattern
+    if (
+      node.object.type === AST_NODE_TYPES.Identifier &&
+      node.object.name === propsParamName &&
+      node.property.type === AST_NODE_TYPES.Identifier
+    ) {
+      markAsUsed(node.property.name);
+      return;
+    }
+
+    // Check for this.props.propertyName or this.props?.propertyName pattern
+    if (
+      node.object.type !== AST_NODE_TYPES.MemberExpression ||
+      node.object.object.type !== AST_NODE_TYPES.ThisExpression ||
+      node.object.property.type !== AST_NODE_TYPES.Identifier ||
+      node.object.property.name !== "props" ||
+      node.property.type !== AST_NODE_TYPES.Identifier
+    ) {
+      return;
+    }
+    markAsUsed(node.property.name);
+  };
+
+  /**
+   * Marks a property as used when it is accessed in a member expression.
+   *
+   * @param node The member expression node.
+   * @param propsParamName The name of the property being tracked.
+   */
+  const markAsUsedForVariableDeclarator = (
+    node: TSESTree.VariableDeclarator,
+    propsParamName: string
+  ): void => {
+    // NOTE: Check for destructuring assignment: const { prop1, prop2 } = props
+    if (
+      node.id.type !== AST_NODE_TYPES.ObjectPattern ||
+      node.init?.type !== AST_NODE_TYPES.Identifier ||
+      node.init.name !== propsParamName
+    ) {
+      return;
+    }
+    const propertyNames = getPropertyNames(node.id.properties);
+    for (const name of propertyNames) {
+      markAsUsed(name);
+    }
+  };
+
+  /**
+   * Marks a property as used when it is assigned in an expression.
+   *
+   * @param node The assignment expression node.
+   * @param propsParamName The name of the property being tracked.
+   */
+  const markAsUsedForAssignmentExpression = (
+    node: TSESTree.AssignmentExpression,
+    propsParamName: string
+  ): void => {
+    // NOTE: Check for this.property = props.property pattern
+    if (
+      node.right.type !== AST_NODE_TYPES.MemberExpression ||
+      node.right.object.type !== AST_NODE_TYPES.Identifier ||
+      node.right.object.name !== propsParamName ||
+      node.right.property.type !== AST_NODE_TYPES.Identifier
+    ) {
+      return;
+    }
+
+    markAsUsed(node.right.property.name);
+
+    // NOTE: this.props = props pattern doesn't mark all properties as used
+    // because we still need to check which properties are actually accessed later
+  };
+
+  /**
+   * Marks all properties in an object pattern as used.
+   *
+   * @param node The object pattern node.
+   */
+  const markAsUsedForObjectPattern = (node: TSESTree.ObjectPattern): void => {
+    for (const propName of getPropertyNames(node.properties)) {
+      markAsUsed(propName);
+    }
+  };
+
+  // ===============================================
+  // Return tracker
+  // ===============================================
+  if (!propUsages.size) return null;
+  return {
+    getUnusedProperties,
+    markAsUsedForMemberExpression,
+    markAsUsedForVariableDeclarator,
+    markAsUsedForAssignmentExpression,
+    markAsUsedForObjectPattern,
+  };
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #166 

### Reason for this change

  CDK Construct development often involves defining props interfaces with multiple properties, but developers may forget to use some of these properties in the constructor implementation. This leads to:

  - Dead code: Unused properties in props interfaces that serve no purpose
  - Maintenance burden: Properties that appear to be used but are actually ignored
  - Developer confusion: Unclear which properties are actually required vs optional
  - Runtime inefficiency: Properties being passed but never utilized

  This ESLint rule helps developers catch these issues early in the development process, improving code quality and reducing maintenance overhead.

### Description of changes

  Implemented a comprehensive ESLint rule that detects unused properties in CDK Construct props interfaces. The rule enforces that all properties defined in the constructor's props parameter are actually used within the constructor body.

### Description of how you validated changes

- [x] unit test
- [x] manual integ test

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
