### PR TITLE
fix: Type errors occur when adding @ts-check comments in eslint.config.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,10 @@ export { configs, rules };
 
 export interface EslintCdkPlugin {
   rules: typeof rules;
-  configs: Readonly<Record<string, FlatConfig.Config>>;
+  configs: Readonly<{
+    recommended: FlatConfig.Config;
+    strict: FlatConfig.Config;
+  }>;
 }
 
 const eslintCdkPlugin: EslintCdkPlugin = {


### PR DESCRIPTION
### Issue # (if applicable)

Closes N/A

### Reason for this change

Because adding `@ts-check` comments in eslint.config.js like the following was causing errors

```js
// @ts-check
import eslint from '@eslint/js';
import tseslint from 'typescript-eslint';
import cdkPlugin from 'eslint-cdk-plugin';

export default tseslint.config(
  eslint.configs.recommended,
  ...tseslint.configs.recommendedTypeChecked,
  {
    languageOptions: {
      parserOptions: {
        projectService: true,
        tsconfigRootDir: import.meta.dirname,
      },
    },
    extends: [
      cdkPlugin.configs.recommended,  // type error
    ]
  },
  {
    files: ['**/*.test.ts', '**/*.spec.ts'],
    rules: {
      'functional/no-expression-statements': 'off',
      'functional/no-return-void': 'off',
    },
  }
);

```

### Description of changes

 Modified to add types to the provided config

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
