### PR TITLE
feat: add "CfnOutput" to ignoredClasses in type checks for Construct and Stack

### DIFF
--- a/src/utils/typeCheck.ts
+++ b/src/utils/typeCheck.ts
@@ -10,7 +10,7 @@ type SuperClassType = "Construct" | "Stack";
  */
 export const isConstructOrStackType = (
   type: Type,
-  ignoredClasses: readonly string[] = ["App", "Stage"] as const
+  ignoredClasses: readonly string[] = ["App", "Stage", "CfnOutput"] as const
 ): boolean => {
   if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
   return isTargetSuperClassType(
@@ -28,7 +28,12 @@ export const isConstructOrStackType = (
  */
 export const isConstructType = (
   type: Type,
-  ignoredClasses: readonly string[] = ["App", "Stage", "Stack"] as const
+  ignoredClasses: readonly string[] = [
+    "App",
+    "Stage",
+    "CfnOutput",
+    "Stack",
+  ] as const
 ): boolean => {
   if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
   return isTargetSuperClassType(type, ["Construct"], isConstructType);


### PR DESCRIPTION
### Reason for this change

Because the rules that should apply to CDK Construct should not apply to `CfnOutput`.

### Description of changes

add "CfnOutput" to ignoredClasses in type checks for Construct and Stack

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/ren-yamanashi/eslint-cdk-plugin/blob/main/CONGRIBUTING.md)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
