### PR TITLE
fix: apply "require-jsdoc" rules even to public property with no accessibility specified

### DIFF
--- a/src/__tests__/require-jsdoc.test.ts
+++ b/src/__tests__/require-jsdoc.test.ts
@@ -77,17 +77,22 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
       ],
     },
     {
-      // WHEN: Construct class without JSDoc comments
+      // WHEN: public property in Construct class without JSDoc comments
       code: `
         class Construct {}
         class TestConstruct extends Construct {
           public prop1: string;
+          prop2: string;
         }
       `,
       errors: [
         {
           messageId: "missingJSDoc",
           data: { propertyName: "prop1" },
+        },
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "prop2" },
         },
       ],
     },

--- a/src/rules/require-jsdoc.ts
+++ b/src/rules/require-jsdoc.ts
@@ -77,7 +77,8 @@ export const requireJSDoc = createRule({
 
         // NOTE: Check if the class extends Construct and the property is public
         const classType = parserServices.getTypeAtLocation(classDeclaration);
-        if (!isConstructType(classType) || node.accessibility !== "public") {
+        const accessibility = node.accessibility ?? "public";
+        if (!isConstructType(classType) || accessibility !== "public") {
           return;
         }
 


### PR DESCRIPTION
### Reason for this change

The `require-jsdoc` rule enforces the inclusion of jsdoc for class public properties and interface properties, since this rule should also apply to public properties for which accessibility is not explicitly stated.

### Description of changes

- ensured that rules apply even in the absence of accessibility

### Description of how you validated changes

- [x] unit test

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
