### PR TITLE
fix: is-resource-with-readonly-interface error condition

### DIFF
--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -236,5 +236,26 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],
     },
+    // WHEN: property type is class with BaseV{number} pattern
+    //       (TableBaseV2 class extends Resource and implements ITableV2)
+    {
+      code: `
+      class Resource {}
+      interface ITableV2 {
+        tableName: string;
+      }
+      export class TableBaseV2 extends Resource implements ITableV2 {
+        readonly tableName: string;
+        constructor() {
+          super();
+          this.tableName = "test-table";
+        }
+      }
+      interface MyConstructProps {
+        table: TableBaseV2;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
   ],
 });

--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -209,5 +209,32 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],
     },
+    // WHEN: property type is class that extends a base class implementing a matching interface
+    //       (S3OriginAccessControl extends OriginAccessControlBase which implements IOriginAccessControl)
+    {
+      code: `
+      class Resource {}
+      interface IOriginAccessControl {
+        originAccessControlId: string;
+      }
+      export abstract class OriginAccessControlBase extends Resource implements IOriginAccessControl {
+        abstract readonly originAccessControlId: string;
+        constructor() {
+          super();
+        }
+      }
+      export class S3OriginAccessControl extends OriginAccessControlBase {
+        readonly originAccessControlId: string;
+        constructor() {
+          super();
+          this.originAccessControlId = "test-id";
+        }
+      }
+      interface MyConstructProps {
+        originAccessControl: S3OriginAccessControl;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
   ],
 });

--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -299,6 +299,7 @@ ruleTester.run(
       //       (TableBaseV2 class extends Resource and implements ITableV2)
       {
         code: `
+          class Construct {}
           class Resource {}
           interface ITableV2 {
             tableName: string;

--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -134,6 +134,30 @@ ruleTester.run(
           }
         `,
       },
+      // WHEN: when implements only IResource interface
+      {
+        code: `
+          class Construct {}
+          interface IResource {
+            resourceId: string;
+          }
+          class Resource {
+            resourceId: string;
+            constructor() {
+              this.resourceId = "resource-id";
+            }
+          }
+          export class MetricFilter extends Resource {
+            readonly metricName: string;
+            constructor() {
+              super();
+            }
+          }
+          class TestClass extends Construct {
+            public test: MetricFilter;
+          }
+        `,
+      },
     ],
     invalid: [
       // WHEN: public field type is class that extends Resource
@@ -239,6 +263,34 @@ ruleTester.run(
           }
           class TestClass extends Construct {
             public test: FargateService;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      // WHEN: property type is class that extends a base class implementing a matching interface
+      //       (S3OriginAccessControl extends OriginAccessControlBase which implements IOriginAccessControl)
+      {
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IOriginAccessControl {
+            originAccessControlId: string;
+          }
+          export abstract class OriginAccessControlBase extends Resource implements IOriginAccessControl {
+            abstract readonly originAccessControlId: string;
+            constructor() {
+              super();
+            }
+          }
+          export class S3OriginAccessControl extends OriginAccessControlBase {
+            readonly originAccessControlId: string;
+            constructor() {
+              super();
+              this.originAccessControlId = "test-id";
+            }
+          }
+          class TestClass extends Construct {
+            public test: S3OriginAccessControl;
           }
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],

--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -295,6 +295,27 @@ ruleTester.run(
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
+      // WHEN: property type is class with BaseV{number} pattern
+      //       (TableBaseV2 class extends Resource and implements ITableV2)
+      {
+        code: `
+          class Resource {}
+          interface ITableV2 {
+            tableName: string;
+          }
+          export class TableBaseV2 extends Resource implements ITableV2 {
+            readonly tableName: string;
+            constructor() {
+              super();
+              this.tableName = "test-table";
+            }
+          }
+          class TestClass extends Construct {
+            public test: TableBaseV2;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
       // WHEN: constructor public property type is class that extends Resource
       //       (BucketBase class extends Resource and implements IBucket interface)
       {

--- a/src/utils/is-resource-with-readonly-interface.ts
+++ b/src/utils/is-resource-with-readonly-interface.ts
@@ -14,7 +14,7 @@ import { isClassType } from "./typecheck/ts-type";
  *
  * This function validates that:
  * 1. The type extends from Resource (AWS CDK resource)
- * 2. The type implements an interface following CDK's read-only interface naming convention
+ * 2. The type or any of its base classes implements an interface following CDK's read-only interface naming convention
  *    - Pattern 1: Class name with I prefix (e.g., Bucket -> IBucket)
  *    - Pattern 2: Class name without Base suffix/prefix with I prefix (e.g., BucketBase -> IBucket, BaseService -> IService)
  *
@@ -26,6 +26,7 @@ import { isClassType } from "./typecheck/ts-type";
  * class Bucket extends Resource implements IBucket { ... }
  * class BucketBase extends Resource implements IBucket { ... }
  * class BaseService extends Resource implements IService { ... }
+ * class S3OriginAccessControl extends OriginAccessControlBase { ... } // where OriginAccessControlBase implements IOriginAccessControl
  *
  * // Returns false for:
  * class CustomResource extends Resource { ... } // No matching interface
@@ -33,90 +34,122 @@ import { isClassType } from "./typecheck/ts-type";
  */
 export const isResourceWithReadonlyInterface = (type: Type): boolean => {
   if (!isResourceType(type) || !type.symbol?.name) return false;
-
-  const className = type.symbol.name;
-  if (className === "Resource" || className === "Construct") return false;
-
-  const implementedInterfaces = getImplementedInterfaceNames(type);
-
-  // Check if any implemented interface matches the class name pattern
-  return implementedInterfaces.some((interfaceName) => {
-    // Extract the simple interface name (remove namespace if present)
-    const simpleInterfaceName = interfaceName.includes(".")
-      ? interfaceName.split(".").pop() ?? interfaceName
-      : interfaceName;
-
-    // Pattern 1: Class name with I prefix (e.g., Bucket -> IBucket, FargateService -> IFargateService)
-    if (simpleInterfaceName === `I${className}`) return true;
-
-    // Pattern 2: Class name without `Base` suffix / prefix with the `I` prefix (e.g., BucketBase -> IBucket, BaseService -> IService)
-    const classNameWithoutBase = className.replace(/^Base|Base$/g, "");
-    if (simpleInterfaceName === `I${classNameWithoutBase}`) return true;
-
-    return false;
-  });
+  if (isIgnoreClass(type.symbol.name)) return false;
+  return hasMatchingInterfaceInHierarchy(type);
 };
 
 /**
- * Retrieves all interface names implemented by a type, including those inherited from base classes
- *
- * This function recursively collects interfaces from:
- * - Direct implements clauses on the class
- * - Implements clauses on all base classes in the inheritance chain
- * - Both simple interface names (e.g., IBucket) and namespace-qualified names (e.g., ecs.IFargateService)
- *
- * @param type - The TypeScript type to analyze
- * @returns Array of interface names (may include namespace prefixes)
+ * Checks if a type or any of its base classes implements an interface matching its class name
+ * @param type - The TypeScript type to check
+ * @returns true if any class in the hierarchy implements a matching interface
  * @private
  */
-const getImplementedInterfaceNames = (type: Type): string[] => {
-  const interfaces = new Set<string>();
+const hasMatchingInterfaceInHierarchy = (type: Type): boolean => {
   const processedTypes = new Set<string>();
 
-  const collectInterfaces = (currentType: Type): void => {
+  const checkTypeAndBases = (currentType: Type): boolean => {
     const symbol = currentType.getSymbol?.() ?? currentType.symbol;
-    if (!symbol?.name) return;
+    if (!symbol?.name) return false;
 
-    if (processedTypes.has(symbol.name)) return;
+    // Skip if already processed
+    if (processedTypes.has(symbol.name)) return false;
     processedTypes.add(symbol.name);
 
-    const declarations = symbol.getDeclarations
-      ? symbol.getDeclarations()
-      : symbol.declarations;
-    if (!declarations?.length) return;
+    const currentClassName = symbol.name;
+    if (isIgnoreClass(currentClassName)) return false;
 
-    declarations.forEach((declaration) => {
-      if (!isClassDeclaration(declaration) || !declaration.heritageClauses) {
-        return;
-      }
+    const directInterfaces = getDirectImplementedInterfaceNames(currentType);
 
-      declaration.heritageClauses.forEach((hc) => {
-        if (!checkHeritageClauseIsImplements(hc)) return;
-
-        hc.types.forEach((typeNode) => {
-          if (typeNode.expression) {
-            if (isIdentifier(typeNode.expression)) {
-              // Simple interface name (e.g., IFargateService)
-              interfaces.add(typeNode.expression.text);
-            } else if (isPropertyAccessExpression(typeNode.expression)) {
-              // Namespace qualified interface name (e.g., ecs.IFargateService)
-              const namespace = typeNode.expression.expression;
-              const interfaceName = typeNode.expression.name;
-              if (isIdentifier(namespace) && isIdentifier(interfaceName)) {
-                interfaces.add(`${namespace.text}.${interfaceName.text}`);
-              }
-            }
-          }
-        });
-      });
-    });
+    // NOTE: Check if any interface matches this class name
+    if (
+      directInterfaces.some((interfaceName) =>
+        checkInterfaceMatchClassName(interfaceName, currentClassName)
+      )
+    ) {
+      return true;
+    }
 
     const baseTypes = currentType.getBaseTypes?.() ?? [];
-    baseTypes.forEach((baseType) => {
-      if (isClassType(baseType)) collectInterfaces(baseType);
-    });
+    return baseTypes.some(
+      (baseType) => isClassType(baseType) && checkTypeAndBases(baseType)
+    );
   };
 
-  collectInterfaces(type);
-  return Array.from(interfaces);
+  return checkTypeAndBases(type);
+};
+
+/**
+ * Checks if the provided interface name matches the class name according to specific patterns
+ *
+ * Patterns:
+ * 1. Class name with I prefix (e.g., Bucket -> IBucket)
+ * 2. Class name without Base suffix/prefix with I prefix (e.g., BucketBase -> IBucket, BaseService -> IService)
+ *
+ * @param interfaceName - The name of the interface to check
+ * @param classname - The name of the class to compare against
+ * @returns boolean - true if the interface name matches the class name patterns, false otherwise
+ */
+const checkInterfaceMatchClassName = (
+  interfaceName: string,
+  classname: string
+) => {
+  const simpleInterfaceName = interfaceName.includes(".")
+    ? interfaceName.split(".").pop() ?? interfaceName
+    : interfaceName;
+
+  // Pattern 1: Class name with I prefix
+  if (simpleInterfaceName === `I${classname}`) return true;
+
+  // Pattern 2: Class name without Base suffix/prefix with I prefix
+  const classNameWithoutBase = classname.replace(/^Base|Base$/g, "");
+
+  return (
+    classNameWithoutBase && simpleInterfaceName === `I${classNameWithoutBase}`
+  );
+};
+
+/**
+ * Retrieves interface names directly implemented by a type (not including inherited interfaces)
+ * @param type - The TypeScript type to analyze
+ * @returns Array of interface names directly implemented by this type
+ * @private
+ */
+const getDirectImplementedInterfaceNames = (type: Type): string[] => {
+  const symbol = type.getSymbol?.() ?? type.symbol;
+  if (!symbol?.name) return [];
+
+  const declarations = symbol.getDeclarations
+    ? symbol.getDeclarations()
+    : symbol.declarations;
+  if (!declarations?.length) return [];
+
+  return declarations.reduce<string[]>((acc, decl) => {
+    if (!isClassDeclaration(decl)) return acc;
+
+    const heritageClauses = decl.heritageClauses;
+    if (!heritageClauses) return acc;
+
+    return heritageClauses.reduce<string[]>((hcAcc, hc) => {
+      if (!checkHeritageClauseIsImplements(hc)) return hcAcc;
+
+      return hc.types.reduce<string[]>((typeAcc, type) => {
+        const expression = type.expression;
+        if (!expression) return typeAcc;
+        if (isIdentifier(expression)) return [...typeAcc, expression.text];
+        if (!isPropertyAccessExpression(expression)) return typeAcc;
+
+        const namespace = expression.expression;
+        const interfaceName = expression.name;
+        if (isIdentifier(namespace) && isIdentifier(interfaceName)) {
+          return [...typeAcc, `${namespace.text}.${interfaceName.text}`];
+        }
+
+        return typeAcc;
+      }, []);
+    }, []);
+  }, []);
+};
+
+const isIgnoreClass = (className: string): boolean => {
+  return className === "Resource" || className === "Construct";
 };

--- a/src/utils/typecheck/cdk.ts
+++ b/src/utils/typecheck/cdk.ts
@@ -41,13 +41,7 @@ export const isConstructType = (
 
 export const isResourceType = (
   type: Type,
-  ignoredClasses: readonly string[] = [
-    "App",
-    "Stage",
-    "CfnOutput",
-    "Construct",
-    "Stack",
-  ] as const
+  ignoredClasses: readonly string[] = [] // App, Stage, CfnOutput, Stack are not extended Resource, so no need to ignore them
 ): boolean => {
   if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
   return isTargetSuperClassType(type, ["Resource"], isResourceType);


### PR DESCRIPTION
This PR fixes the error condition logic in the is-resource-with-readonly-interface rule. The changes include:

  - Simplified resource type detection by removing unnecessary ignoredClasses from the isResourceType function
  - Enhanced interface validation with updated isResourceWithReadonlyInterface logic
  - Improved test coverage by adding tests for TableBaseV2 class and including missing Construct class in related tests

  The fix ensures the ESLint rule properly identifies CDK resources with readonly interfaces, preventing false positives and improving accuracy in code analysis.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
