### PR TITLE
fix: add npm registry URL for OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,7 @@ jobs:
           node-version: 22.15.0
           # This will install the latest npm version
           check-latest: true
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Get package info
         id: package


### PR DESCRIPTION
- Add registry-url to Node.js setup in release job
- Enable npm OIDC authentication without secrets
- Fix ENEEDAUTH error when publishing with provenance
