### PR TITLE
fix: support array types in no-construct-in-interface rule

### DIFF
--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -66,6 +66,19 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
     {
       code: `
       class Resource {}
+      export abstract class BaseLoadBalancer extends Resource {
+        constructor() {
+          super();
+        }
+      }
+      interface MyConstructProps {
+        bucket: BaseLoadBalancer[];
+      }
+      `,
+    },
+    {
+      code: `
+      class Resource {}
       interface IVersion {
         version: string;
       }
@@ -81,9 +94,9 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
     },
   ],
   invalid: [
+    // WHEN: property type is class that extends Resource
+    //       (Bucket class extends Resource and indirectly implements IBucket interface)
     {
-      // WHEN: property type is class that extends Resource
-      //       (Bucket class extends Resource and indirectly implements IBucket interface)
       code: `
       class Resource {}
       interface IBucket {
@@ -253,6 +266,32 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       interface MyConstructProps {
         table: TableBaseV2;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    // WHEN: property type is array of class that extends Resource
+    {
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        bucket: Bucket[];
       }
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],

--- a/src/utils/getArrayElementType.ts
+++ b/src/utils/getArrayElementType.ts
@@ -1,0 +1,14 @@
+import { Type } from "typescript";
+
+import { isArrayType } from "./typecheck/ts-type";
+
+export const getArrayElementType = (type: Type): Type | undefined => {
+  if (!isArrayType(type)) return undefined;
+
+  // Get type arguments for Array<T>
+  if ("typeArguments" in type && Array.isArray(type.typeArguments)) {
+    return (type.typeArguments as Type[])[0];
+  }
+
+  return undefined;
+};

--- a/src/utils/typecheck/ts-type.ts
+++ b/src/utils/typecheck/ts-type.ts
@@ -13,3 +13,15 @@ const getSymbol = (type: Type): Symbol | undefined => {
 export const isClassType = (type: Type): boolean => {
   return getSymbol(type)?.flags === SYMBOL_FLAGS.CLASS;
 };
+
+export const isArrayType = (type: Type): boolean => {
+  const symbol = getSymbol(type);
+  if (symbol?.name === "Array") return true;
+
+  if ("target" in type && type.target) {
+    const targetSymbol = getSymbol(type.target as Type);
+    return targetSymbol?.name === "Array";
+  }
+
+  return false;
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #216.

### Reason for this change

The `no-construct-in-interface` rule did not detect CDK Construct types when they were used as array types in interface properties. For example, `bucket: Bucket[]` was not being flagged as an error even though `Bucket` is a CDK Construct type.

### Description of changes

- Added `isArrayType()` function to `ts-type.ts` to check if a TypeScript type is an Array
- Created `getArrayElementType.ts` utility to extract the element type from `Array<T>`
- Updated the `no-construct-in-interface` rule to:
  - Check array properties for CDK Construct element types
  - Report errors with proper type names including `[]` suffix for arrays
- Added comprehensive test cases covering array type validation

### Description of how you validated changes

- Added unit tests to verify array type detection works correctly
- Existing test suite passes with the new changes
- Tested with various array patterns including `Bucket[]`, `BaseLoadBalancer[]`, etc.
- Verified error messages properly display array notation (e.g., `Bucket[]`)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_