### PR TITLE
fix: support array types in no-construct-in-public-property-of-construct rule

### DIFF
--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -347,6 +347,62 @@ ruleTester.run(
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
+      // WHEN: public field type is array of class that extends Resource
+      {
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public buckets: Bucket[];
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      // WHEN: constructor public property type is array of class that extends Resource
+      {
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public buckets: Bucket[]) {
+              super();
+            }
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
     ],
   }
 );


### PR DESCRIPTION
### Issue # (if applicable)

Closes #218.

### Reason for this change

The `no-construct-in-public-property-of-construct` rule did not detect CDK Construct types when they were used as array types in public properties or constructor parameters. For example, `public buckets: Bucket[]` was not being flagged as an error even though `Bucket` is a CDK Construct type.

### Description of changes

- Updated `validatePublicPropertyOfConstruct` function to check array types
- Updated `validateConstructorParameterProperty` function to check array types
- Imported `getArrayElementType` utility to extract element types from arrays
- Added comprehensive test cases covering:
  - Public properties with array types
  - Constructor parameters with array types
- Error messages now properly display array notation (e.g., `Bucket[]`)

### Description of how you validated changes

- Added unit tests for array type detection in both public properties and constructor parameters
- All existing tests continue to pass
- Tested with various array patterns including `Bucket[]`, `BucketBase[]`, etc.
- Verified error messages correctly display the array notation

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_