### PR TITLE
ci: fix deploy job permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
     permissions:
       contents: read
       pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
The deploy job required the `id-token: write` permission, so I added it.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
