### PR TITLE
chore: add `migrate-disable-comments` rule for "recommended" and "strict"

### DIFF
--- a/src/configs/classic-config.ts
+++ b/src/configs/classic-config.ts
@@ -14,6 +14,7 @@ const createClassicConfig = (
 
 export const recommended = createClassicConfig({
   "awscdk/construct-constructor-property": "error",
+  "awscdk/migrate-disable-comments": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",
   "awscdk/no-construct-stack-suffix": "error",
@@ -34,6 +35,7 @@ export const recommended = createClassicConfig({
 
 export const strict = createClassicConfig({
   "awscdk/construct-constructor-property": "error",
+  "awscdk/migrate-disable-comments": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",
   "awscdk/no-construct-stack-suffix": "error",

--- a/src/configs/flat-config.ts
+++ b/src/configs/flat-config.ts
@@ -32,6 +32,7 @@ const createFlatConfig = (
 
 export const recommended = createFlatConfig({
   "awscdk/construct-constructor-property": "error",
+  "awscdk/migrate-disable-comments": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",
   "awscdk/no-construct-stack-suffix": "error",
@@ -44,11 +45,15 @@ export const recommended = createFlatConfig({
   "awscdk/no-unused-props": "error",
   "awscdk/no-variable-construct-id": "error",
   "awscdk/pascal-case-construct-id": "error",
-  "awscdk/require-passing-this": ["error", { allowNonThisAndDisallowScope: true }],
+  "awscdk/require-passing-this": [
+    "error",
+    { allowNonThisAndDisallowScope: true },
+  ],
 });
 
 export const strict = createFlatConfig({
   "awscdk/construct-constructor-property": "error",
+  "awscdk/migrate-disable-comments": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",
   "awscdk/no-construct-stack-suffix": "error",


### PR DESCRIPTION

### Reason for this change

To enable comment migration with `eslint --fix` without modifying the rule files

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
