### PR TITLE
chore: group dependabot updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       timezone: "Asia/Tokyo"
     commit-message:
       prefix: "chore"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION

### Reason for this change

Currently, Dependabot creates individual PRs for each dependency update, which can result in multiple PRs per week. Grouping all updates into a single weekly PR will improve review efficiency and repository management.

### Description of changes

Added `groups` configuration to `.github/dependabot.yml`:
- Created a `dependencies` group
- Used pattern `*` to group all dependency updates into a single PR

With this configuration, Dependabot will run once a week (every Monday at 02:00 JST) and submit all available dependency updates in a single grouped PR.

### Description of how you validated changes

- Verified the Dependabot configuration file syntax is correct
- Implemented `groups` configuration following GitHub's official Dependabot documentation

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
