### PR TITLE
refactor(no-construct-in-public-property-of-construct): improve public property validation and type handling

### DIFF
--- a/src/core/ast-node/finder/public-property.ts
+++ b/src/core/ast-node/finder/public-property.ts
@@ -1,0 +1,76 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+import { findConstructor } from "./constructor";
+
+export type PublicProperty = {
+  /**
+   * Name of the public property
+   */
+  name: string;
+  /**
+   * AST node representing the public property
+   */
+  node:
+    | TSESTree.PropertyDefinitionComputedName
+    | TSESTree.PropertyDefinitionNonComputedName
+    | TSESTree.TSParameterProperty;
+};
+
+export const findPublicPropertiesInClass = (
+  node: TSESTree.ClassDeclaration
+): PublicProperty[] => {
+  const constructorProperties = findPropertiesInConstructor(node);
+  const classElementProperties = findPropertiesInClassElement(node);
+  return [...constructorProperties, ...classElementProperties];
+}
+
+const findPropertiesInConstructor = (
+  node: TSESTree.ClassDeclaration
+) => {
+  const constructor = findConstructor(node);
+  if (!constructor) return [];
+  return constructor.value.params.flatMap(
+    (property) => findPublicProperty(property) ?? []
+  );
+}
+
+const findPropertiesInClassElement = (node: TSESTree.ClassDeclaration): PublicProperty[] => {
+  return node.body.body.flatMap(
+    (property) => findPublicProperty(property) ?? []
+  );
+};
+
+const findPublicProperty = (
+  property: TSESTree.Parameter | TSESTree.ClassElement
+): PublicProperty | undefined => {
+  switch (property.type) {
+    // NOTE: get from constructor
+    case AST_NODE_TYPES.TSParameterProperty: {
+      if (property.parameter.type !== AST_NODE_TYPES.Identifier) {
+        return;
+      }
+      if (["private", "protected"].includes(property.accessibility ?? "")) {
+        return;
+      }
+      if (!property.parameter.typeAnnotation) return;
+      return {
+        name: property.parameter.name,
+        node: property,
+      };
+    }
+    // NOTE: get from class element
+    case AST_NODE_TYPES.PropertyDefinition: {
+      if (property.key.type !== AST_NODE_TYPES.Identifier) {
+        return;
+      }
+      if (["private", "protected"].includes(property.accessibility ?? "")) {
+        return;
+      }
+      if (!property.typeAnnotation) return;
+      return {
+        name: property.key.name,
+        node: property,
+      };
+    }
+  }
+};

--- a/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,17 +1,21 @@
 import {
-  AST_NODE_TYPES,
   ESLintUtils,
   ParserServicesWithTypeInformation,
   TSESLint,
   TSESTree,
 } from "@typescript-eslint/utils";
 
-import { findConstructor } from "../core/ast-node/finder/constructor";
+import { findPublicPropertiesInClass } from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
 
 type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
+
+type PublicProperty = {
+  name: string;
+  node: TSESTree.Parameter | TSESTree.ClassElement;
+};
 
 /**
  * Disallow Construct types in public property of Construct
@@ -38,88 +42,30 @@ export const noConstructInPublicPropertyOfConstruct = createRule({
       ClassDeclaration(node) {
         const type = parserServices.getTypeAtLocation(node);
         if (!isConstructOrStackType(type)) return;
-        checkPublicPropertyInClassElement(node, context, parserServices);
-        checkParameterPropertiesInConstructor(node, context, parserServices);
+        const publicProperties = findPublicPropertiesInClass(node);
+        for (const publicProperty of publicProperties) {
+          validatePublicProperty(publicProperty, context, parserServices);
+        }
       },
     };
   },
 });
 
-const checkPublicPropertyInClassElement = (
-  node: TSESTree.ClassDeclaration,
+const validatePublicProperty = (
+  publicProperty: PublicProperty,
   context: Context,
   parserServices: ParserServicesWithTypeInformation
 ) => {
-  for (const property of node.body.body) {
-    validateProperty(property, context, parserServices);
-  }
-};
-
-const checkParameterPropertiesInConstructor = (
-  node: TSESTree.ClassDeclaration,
-  context: Context,
-  parserServices: ParserServicesWithTypeInformation
-) => {
-  const constructor = findConstructor(node);
-  if (!constructor) return;
-  for (const property of constructor.value.params) {
-    validateProperty(property, context, parserServices);
-  }
-};
-
-const validateProperty = (
-  property: TSESTree.Parameter | TSESTree.ClassElement,
-  context: Context,
-  parserServices: ParserServicesWithTypeInformation
-) => {
-  const publicProperty = getPublicProperty(property);
-  if (!publicProperty) return;
-
-  const type = parserServices.getTypeAtLocation(publicProperty.type);
+  const type = parserServices.getTypeAtLocation(publicProperty.node);
   const constructType = findTypeOfCdkConstruct(type);
   if (constructType) {
     context.report({
-      node: property,
+      node: publicProperty.node,
       messageId: "invalidPublicPropertyOfConstruct",
       data: {
         propertyName: publicProperty.name,
         typeName: constructType.symbol.name,
       },
     });
-  }
-};
-
-const getPublicProperty = <
-  T extends TSESTree.Parameter | TSESTree.ClassElement
->(
-  property: T
-): { name: string; type: T } | undefined => {
-  switch (property.type) {
-    case AST_NODE_TYPES.TSParameterProperty: {
-      if (property.parameter.type !== AST_NODE_TYPES.Identifier) {
-        return;
-      }
-      if (["private", "protected"].includes(property.accessibility ?? "")) {
-        return;
-      }
-      if (!property.parameter.typeAnnotation) return;
-      return {
-        name: property.parameter.name,
-        type: property,
-      };
-    }
-    case AST_NODE_TYPES.PropertyDefinition: {
-      if (property.key.type !== AST_NODE_TYPES.Identifier) {
-        return;
-      }
-      if (["private", "protected"].includes(property.accessibility ?? "")) {
-        return;
-      }
-      if (!property.typeAnnotation) return;
-      return {
-        name: property.key.name,
-        type: property,
-      };
-    }
   }
 };

--- a/src/rules/no-mutable-public-property-of-construct.ts
+++ b/src/rules/no-mutable-public-property-of-construct.ts
@@ -1,7 +1,16 @@
-import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import {
+  ESLintUtils,
+  TSESLint
+} from "@typescript-eslint/utils";
 
+import {
+  findPublicPropertiesInClass,
+  PublicProperty,
+} from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { createRule } from "../shared/create-rule";
+
+type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
 
 /**
  * Disallow mutable public properties of Construct
@@ -32,45 +41,44 @@ export const noMutablePublicPropertyOfConstruct = createRule({
         const type = parserServices.getTypeAtLocation(node);
         if (!isConstructOrStackType(type)) return;
 
-        for (const member of node.body.body) {
-          // NOTE: check property definition
-          if (
-            member.type !== AST_NODE_TYPES.PropertyDefinition ||
-            member.key.type !== AST_NODE_TYPES.Identifier
-          ) {
-            continue;
-          }
-
-          // NOTE: Skip private and protected fields
-          if (["private", "protected"].includes(member.accessibility ?? "")) {
-            continue;
-          }
-
-          // NOTE: Skip if readonly is present
-          if (member.readonly) continue;
-
-          context.report({
-            node: member,
-            messageId: "invalidPublicPropertyOfConstruct",
-            data: {
-              propertyName: member.key.name,
-            },
-            fix: (fixer) => {
-              const accessibility = member.accessibility ? "public " : "";
-              const paramText = sourceCode.getText(member);
-              const [key, value] = paramText.split(":");
-              const replacedKey = key.startsWith("public ")
-                ? key.replace("public ", "")
-                : key;
-
-              return fixer.replaceText(
-                member,
-                `${accessibility}readonly ${replacedKey}:${value}`
-              );
-            },
+        const publicProperties = findPublicPropertiesInClass(node);
+        for (const property of publicProperties) {
+          validatePublicProperty({
+            publicProperty: property,
+            context,
+            sourceCode,
           });
         }
       },
     };
   },
 });
+
+const validatePublicProperty = (args: {
+  publicProperty: PublicProperty;
+  context: Context;
+  sourceCode: Readonly<TSESLint.SourceCode>;
+}) => {
+  const { publicProperty, context, sourceCode } = args;
+  if (publicProperty.node.readonly) return;
+
+  context.report({
+    node: publicProperty.node,
+    messageId: "invalidPublicPropertyOfConstruct",
+    data: {
+      propertyName: publicProperty.name,
+    },
+    fix: (fixer) => {
+      const accessibility = publicProperty.node.accessibility ? "public " : "";
+      const paramText = sourceCode.getText(publicProperty.node);
+      const [key, value] = paramText.split(":");
+      const replacedKey = key.startsWith("public ")
+        ? key.replace("public ", "")
+        : key;
+      return fixer.replaceText(
+        publicProperty.node,
+        `${accessibility}readonly ${replacedKey}:${value}`
+      );
+    },
+  });
+};


### PR DESCRIPTION
### Reason for this change

Two rules (no-construct-in-public-property-of-construct and no-mutable-public-property-of-construct) had duplicated logic for finding public properties in classes. This duplication made the codebase harder to maintain.

### Description of changes

Two rules (no-construct-in-public-property-of-construct and no-mutable-public-property-of-construct) had duplicated logic for finding public properties in classes. This duplication made the codebase harder to maintain.

### Description of how you validated changes

- [x] pass CI

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
