### PR TITLE
fix: correct yarn remove command syntax in uninstall function

### DIFF
--- a/scripts/migration/migrate-plugin/uninstall.ts
+++ b/scripts/migration/migrate-plugin/uninstall.ts
@@ -41,7 +41,7 @@ const uninstall = (
       case PACKAGE_MANGER.NPM:
         return `npm uninstall${devFlag} eslint-cdk-plugin`;
       case PACKAGE_MANGER.YARN:
-        return `yarn remove${devFlag} eslint-cdk-plugin`;
+        return `yarn remove eslint-cdk-plugin${devFlag}`;
       case PACKAGE_MANGER.PNPM:
         return `pnpm remove${devFlag} eslint-cdk-plugin`;
     }


### PR DESCRIPTION
### Reason for this change

Because the command to uninstall a package with yarn was incorrect.

### Description of changes

```diff
- yarn remove -D <package-name>
+ yarn remove <package-name> -D
```

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
