### PR TITLE
chore: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,21 +13,7 @@ updates:
       dependencies:
         patterns:
           - "*"
-
-  # Keep ESLint v9 for classic config example
-  - package-ecosystem: "npm"
-    directory: "/examples/classic-config"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "02:00"
-      timezone: "Asia/Tokyo"
-    commit-message:
-      prefix: "chore"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
+    # Since typescript-eslint does not yet fully support ESLint v10, we will ignore the major update for ESLint for now.
     ignore:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Reason for this change

To prevent ESLint v10 from being installed

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
