### PR TITLE
fix(require-passing-this): should not flag resources defined outside Construct class

### DIFF
--- a/docs/ja/rules/require-passing-this.md
+++ b/docs/ja/rules/require-passing-this.md
@@ -23,6 +23,8 @@ Construct のコンストラクタの第一引数へ `this` 以外の値 (特に
 - 生成される CloudFormation テンプレートのリソース階層が正しくない
 - 予期しないリソースの命名
 
+> **Note:** このルールは `Construct` または `Stack` を継承したクラスの内部でのみ適用されます。Construct クラス外の関数など、`this` が利用できない場合は検出対象外です。
+
 ---
 
 #### 🔧 使用方法
@@ -57,6 +59,11 @@ export class MyConstruct extends Construct {
     // ✅ 他の Construct インスタンス (この場合は sample) をスコープとして指定できる
     new OtherConstruct(sample, "Child");
   }
+}
+
+// ✅ Construct クラス外の関数では検出されない
+function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
 }
 ```
 

--- a/docs/rules/require-passing-this.md
+++ b/docs/rules/require-passing-this.md
@@ -16,11 +16,13 @@ import Playground from '../components/Playground.vue'
 
 This rule enforces passing `this` as the scope when creating new Construct instances within a Construct.
 
-When creating AWS CDK resources, passing `this` as the scope to child Constructs is crucial for maintaining the correct resource hierarchy.  
+When creating AWS CDK resources, passing `this` as the scope to child Constructs is crucial for maintaining the correct resource hierarchy.
 Passing other values as the scope (especially the `scope` variable received by the parent's constructor) can lead to:
 
 - Incorrect resource hierarchy in the generated CloudFormation template
 - Unexpected resource naming
+
+> **Note:** This rule only applies inside classes that extend `Construct` or `Stack`. It does not flag cases where `this` is not available, such as functions outside Construct classes.
 
 ---
 
@@ -56,6 +58,11 @@ export class MyConstruct extends Construct {
     // ✅ `sample` (an instance of a Construct) is allowed as scope.
     new OtherConstruct(sample, "Child");
   }
+}
+
+// ✅ Functions outside Construct classes are not flagged.
+function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
 }
 ```
 

--- a/examples/eslint/lib/require-passing-this.ts
+++ b/examples/eslint/lib/require-passing-this.ts
@@ -36,3 +36,8 @@ export class _MyConstruct extends Construct {
     new Bucket(scope, "SampleBucket");
   }
 }
+
+// ✅ Functions outside Construct classes are not flagged.
+export function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
+}

--- a/examples/eslint/lib/require-passing-this.ts
+++ b/examples/eslint/lib/require-passing-this.ts
@@ -38,6 +38,6 @@ export class _MyConstruct extends Construct {
 }
 
 // ✅ Functions outside Construct classes are not flagged.
-export function createBucket(scope: Construct, id: string) {
-  new Bucket(scope, id);
+export function createBucket(scope: Construct) {
+  new Bucket(scope, "SampleBucket");
 }

--- a/src/__tests__/require-passing-this.test.ts
+++ b/src/__tests__/require-passing-this.test.ts
@@ -65,6 +65,50 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       }
       `,
     },
+    // WHEN: new expression is inside a standalone function (no class context)
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      function createResource(scope: Construct, id: string) {
+        new SampleConstruct(scope, id);
+      }
+      `,
+    },
+    // WHEN: new expression is inside an arrow function (no class context)
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      const createResource = (scope: Construct, id: string) => {
+        new SampleConstruct(scope, id);
+      };
+      `,
+    },
+    // WHEN: new expression is inside a class that does not extend Construct
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class NotAConstruct {
+        create(scope: Construct) {
+          new SampleConstruct(scope, "Id");
+        }
+      }
+      `,
+    },
     // WHEN: allowNonThisAndDisallowScope is true and passing a non-scope variable
     {
       code: `

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,9 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  TSESLint,
-  TSESTree,
-} from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
@@ -62,8 +57,7 @@ export const requirePassingThis = createRule({
         // NOTE: Only flag when inside a Construct/Stack class where `this` is available
         const enclosingClass = findEnclosingClass(node);
         if (!enclosingClass) return;
-        const enclosingClassType =
-          parserServices.getTypeAtLocation(enclosingClass);
+        const enclosingClassType = parserServices.getTypeAtLocation(enclosingClass);
         if (!isConstructOrStackType(enclosingClassType)) return;
 
         const argument = node.arguments[0];
@@ -88,10 +82,7 @@ export const requirePassingThis = createRule({
         }
         // NOTE: If `allowNonThisAndDisallowScope` is true, allow non-`this` values except `scope` variable
         // Check if the argument is the `scope` variable
-        if (
-          argument.type === AST_NODE_TYPES.Identifier &&
-          argument.name === "scope"
-        ) {
+        if (argument.type === AST_NODE_TYPES.Identifier && argument.name === "scope") {
           context.report({
             node: argument,
             messageId: "missingPassingThis",
@@ -108,9 +99,7 @@ export const requirePassingThis = createRule({
 /**
  * Find the enclosing ClassDeclaration from a given node
  */
-const findEnclosingClass = (
-  node: TSESTree.Node,
-): TSESTree.ClassDeclaration | undefined => {
+const findEnclosingClass = (node: TSESTree.Node): TSESTree.ClassDeclaration | undefined => {
   let current: TSESTree.Node | undefined = node.parent;
   while (current) {
     if (current.type === AST_NODE_TYPES.ClassDeclaration) return current;

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,6 +1,12 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint } from "@typescript-eslint/utils";
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESLint,
+  TSESTree,
+} from "@typescript-eslint/utils";
 
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
 
@@ -53,6 +59,13 @@ export const requirePassingThis = createRule({
 
         if (!isConstructType(type) || !node.arguments.length) return;
 
+        // NOTE: Only flag when inside a Construct/Stack class where `this` is available
+        const enclosingClass = findEnclosingClass(node);
+        if (!enclosingClass) return;
+        const enclosingClassType =
+          parserServices.getTypeAtLocation(enclosingClass);
+        if (!isConstructOrStackType(enclosingClassType)) return;
+
         const argument = node.arguments[0];
 
         // NOTE: If the first argument is already `this`, it's valid
@@ -75,7 +88,10 @@ export const requirePassingThis = createRule({
         }
         // NOTE: If `allowNonThisAndDisallowScope` is true, allow non-`this` values except `scope` variable
         // Check if the argument is the `scope` variable
-        if (argument.type === AST_NODE_TYPES.Identifier && argument.name === "scope") {
+        if (
+          argument.type === AST_NODE_TYPES.Identifier &&
+          argument.name === "scope"
+        ) {
           context.report({
             node: argument,
             messageId: "missingPassingThis",
@@ -88,3 +104,17 @@ export const requirePassingThis = createRule({
     };
   },
 });
+
+/**
+ * Find the enclosing ClassDeclaration from a given node
+ */
+const findEnclosingClass = (
+  node: TSESTree.Node,
+): TSESTree.ClassDeclaration | undefined => {
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current) {
+    if (current.type === AST_NODE_TYPES.ClassDeclaration) return current;
+    current = current.parent;
+  }
+  return undefined;
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #427

### Reason for this change

`require-passing-this` rule incorrectly flags `new` expressions in standalone utility functions and classes that do not extend `Construct`.\
In these contexts, `this` is not available as an alternative to the `scope` parameter, so the rule's suggestion to replace it with `this` is invalid.

### Description of how you validated changes

- Added valid test cases:

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
