### PR TITLE
fix(no-variable-construct-id): should not flag functions outside Construct classes

### DIFF
--- a/docs/ja/rules/no-variable-construct-id.md
+++ b/docs/ja/rules/no-variable-construct-id.md
@@ -68,6 +68,11 @@ class MyConstruct extends Construct {
     return new Bucket(this, id);
   }
 }
+
+// ✅ Construct クラス外の関数では検出されない
+function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
+}
 ```
 
 #### ❌ 不適切な例

--- a/docs/rules/no-variable-construct-id.md
+++ b/docs/rules/no-variable-construct-id.md
@@ -68,6 +68,11 @@ class MyConstruct extends Construct {
     return new Bucket(this, id);
   }
 }
+
+// ✅ Functions outside Construct classes are not flagged.
+function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
+}
 ```
 
 #### ❌ Incorrect Example

--- a/examples/eslint/lib/no-variable-construct-id.ts
+++ b/examples/eslint/lib/no-variable-construct-id.ts
@@ -66,3 +66,8 @@ app.synth();
 
 // ✅ when instance of Stage
 new Stage(app, 1 + "StageConstruct");
+
+// ✅ Functions outside Construct classes are not flagged.
+export function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
+}

--- a/examples/eslint/lib/require-passing-this.ts
+++ b/examples/eslint/lib/require-passing-this.ts
@@ -38,6 +38,6 @@ export class _MyConstruct extends Construct {
 }
 
 // ✅ Functions outside Construct classes are not flagged.
-export function createBucket(scope: Construct) {
-  new Bucket(scope, "SampleBucket");
+export function createBucket(scope: Construct, id: string) {
+  new Bucket(scope, id);
 }

--- a/src/__tests__/no-variable-construct-id.test.ts
+++ b/src/__tests__/no-variable-construct-id.test.ts
@@ -229,6 +229,36 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       }
       `,
     },
+    // WHEN: new expression is inside a standalone function (no class context)
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      function createResource(scope: Construct, id: string) {
+        new TargetConstruct(scope, id);
+      }
+      `,
+    },
+    // WHEN: new expression is inside a class that does not extend Construct
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class NotAConstruct {
+        create(scope: Construct, id: string) {
+          new TargetConstruct(scope, id);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: id is variable

--- a/src/core/ast-node/finder/enclosing-class.ts
+++ b/src/core/ast-node/finder/enclosing-class.ts
@@ -1,0 +1,12 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Find the enclosing ClassDeclaration from a given node
+ * @param node The node to start searching from
+ * @returns The enclosing ClassDeclaration or undefined if not found
+ */
+export const findEnclosingClass = (node: TSESTree.Node): TSESTree.ClassDeclaration | undefined => {
+  if (!node.parent) return undefined;
+  if (node.parent.type === AST_NODE_TYPES.ClassDeclaration) return node.parent;
+  return findEnclosingClass(node.parent);
+};

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -1,6 +1,8 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
+import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
 
@@ -31,6 +33,13 @@ export const noVariableConstructId = createRule({
         const type = parserServices.getTypeAtLocation(node);
 
         if (!isConstructType(type) || node.arguments.length < 2) return;
+
+        // NOTE: Skip when inside a class that is not Construct/Stack
+        const enclosingClass = findEnclosingClass(node);
+        const enclosingClassType = enclosingClass
+          ? parserServices.getTypeAtLocation(enclosingClass)
+          : undefined;
+        if (enclosingClassType && !isConstructOrStackType(enclosingClassType)) return;
 
         const constructorPropertyNames = findConstructorPropertyNames(type);
         if (constructorPropertyNames[1] !== "id") return;
@@ -93,6 +102,12 @@ const shouldSkipIdValidation = (node: TSESTree.Node): boolean => {
     // Constructs in arrow functions are also intended to be called multiple times.
     // This includes usages of array methods like forEach, map, etc.
     if (current.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+      return true;
+    }
+
+    // Constructs in standalone functions (outside of classes) are intended to be called
+    // multiple times with different IDs
+    if (current.type === AST_NODE_TYPES.FunctionDeclaration) {
       return true;
     }
 

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, TSESLint } from "@typescript-eslint/utils";
 
+import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
@@ -95,15 +96,3 @@ export const requirePassingThis = createRule({
     };
   },
 });
-
-/**
- * Find the enclosing ClassDeclaration from a given node
- */
-const findEnclosingClass = (node: TSESTree.Node): TSESTree.ClassDeclaration | undefined => {
-  let current: TSESTree.Node | undefined = node.parent;
-  while (current) {
-    if (current.type === AST_NODE_TYPES.ClassDeclaration) return current;
-    current = current.parent;
-  }
-  return undefined;
-};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #432

### Reason for this change

The `no-variable-construct-id` rule was flagging false positives in contexts outside of Construct/Stack classes, such as standalone functions and classes that don't extend Construct.

### Description of how you validated changes

- Added test cases for no-variable-construct-id

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
