### PR TITLE
feat: support oxlint

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^24.10.13",
     "eslint": "^10.0.0",
     "eslint-plugin-awscdk": "workspace:*",
-    "oxlint": "^1.68.0",
+    "oxlint": "1.66.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.56.0"
   }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eslint-plugin-awscdk/example-eslint",
+  "name": "@eslint-plugin-awscdk/example",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -53,15 +53,11 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^24.10.13",
     "@typescript-eslint/parser": "^8.58.0",
-    "@typescript-eslint/rule-tester": "^8.58.0",
-    "@typescript-eslint/utils": "^8.58.0",
-    "@typescript/native-preview": "7.0.0-dev.20260608.1",
+    "@typescript/native-preview": "7.0.0-dev.20260516.1",
     "@voidzero-dev/vite-plus-core": "^0.1.11",
     "corsa-oxlint": "0.43.0",
     "eslint": "^10.0.0",
-    "secretlint": "^13.0.0",
-    "typescript": "6.0.0-dev.20260416",
-    "typescript-eslint": "^8.58.0",
+    "typescript": "^6.0.2",
     "vite-plus": "^0.1.11"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,12 @@
     "@typescript-eslint/parser": "^8.58.0",
     "@typescript-eslint/rule-tester": "^8.58.0",
     "@typescript-eslint/utils": "^8.58.0",
+    "@typescript/native-preview": "7.0.0-dev.20260608.1",
     "@voidzero-dev/vite-plus-core": "^0.1.11",
+    "corsa-oxlint": "0.43.0",
     "eslint": "^10.0.0",
     "secretlint": "^13.0.0",
-    "typescript": "^6.0.2",
+    "typescript": "6.0.0-dev.20260416",
     "typescript-eslint": "^8.58.0",
     "vite-plus": "^0.1.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@^0.1.11
   vitest: npm:@voidzero-dev/vite-plus-test@^0.1.11
+  oxlint-tsgolint: 0.22.0
+  oxlint: 1.66.0
 
 importers:
 
@@ -20,37 +22,25 @@ importers:
         version: 24.10.15
       '@typescript-eslint/parser':
         specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/rule-tester':
-        specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/utils':
-        specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260608.1
-        version: 7.0.0-dev.20260608.1
+        specifier: 7.0.0-dev.20260516.1
+        version: 7.0.0-dev.20260516.1
       '@voidzero-dev/vite-plus-core':
         specifier: ^0.1.11
-        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)
+        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)
       corsa-oxlint:
         specifier: 0.43.0
-        version: 0.43.0(oxlint-tsgolint@0.23.0)
+        version: 0.43.0(oxlint-tsgolint@0.22.0)
       eslint:
         specifier: ^10.0.0
         version: 10.4.1(jiti@2.6.1)
-      secretlint:
-        specifier: ^13.0.0
-        version: 13.0.2
       typescript:
-        specifier: 6.0.0-dev.20260416
-        version: 6.0.0-dev.20260416
-      typescript-eslint:
-        specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+        specifier: ^6.0.2
+        version: 6.0.3
       vite-plus:
         specifier: ^0.1.11
-        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
 
   docs:
     devDependencies:
@@ -86,8 +76,8 @@ importers:
         specifier: workspace:*
         version: link:..
       oxlint:
-        specifier: ^1.68.0
-        version: 1.68.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
+        specifier: 1.66.0
+        version: 1.66.0(oxlint-tsgolint@0.22.0)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -110,22 +100,8 @@ packages:
       - jsonschema
       - semver
 
-  '@azu/format-text@1.0.2':
-    resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
-
-  '@azu/style-format@1.0.1':
-    resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
-
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -701,50 +677,38 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
-    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+  '@oxlint-tsgolint/darwin-arm64@0.22.0':
+    resolution: {integrity: sha512-/exgXceakHbQrzaHTtKOe7MuDATaWMCCWpsCDQCZKeYhLGXzComipTrCYnHzAXrdnNBb5r5K+RRf5A6ormrhMA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
-    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+  '@oxlint-tsgolint/darwin-x64@0.22.0':
+    resolution: {integrity: sha512-xFGdIahlmUbK+/MpZ5y08D0ewMGLDbd2Vki5wxVFYg50lSrtgPAtdDl+kqKZLNaFu0zpMar8n9wv1le05sL/jw==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
-    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+  '@oxlint-tsgolint/linux-arm64@0.22.0':
+    resolution: {integrity: sha512-53RvC9f77eUo+V1dfQNwGVnsIfPJFMibRR0ee128EUpYNDOZe/ojmCfuXJeU7cY91V7r7fZSm42KPJocXUX8og==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
-    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+  '@oxlint-tsgolint/linux-x64@0.22.0':
+    resolution: {integrity: sha512-evZcJAZ9hjNyuN69RnXwbt+U2pAOcYt+yvqukgugiCkRm4iBZ0R0CvpY1tgfG2XcGUhEPh8dljO+nPZTEVGpCQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
-    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+  '@oxlint-tsgolint/win32-arm64@0.22.0':
+    resolution: {integrity: sha512-7jTO+k1mr5BxRAI2fxc1NRcE3MAbHNZ0Vef9SD1yAR6d1E6qEv5D/D7yuHpQpw6AO3qoecSVo2Jzr+JirN61+w==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
-    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+  '@oxlint-tsgolint/win32-x64@0.22.0':
+    resolution: {integrity: sha512-7lbl9XFcqO+scsynxMzTQdl0XUe6sBUCyY/oGWvCB+JmV4U+70vzSyZJdTEzzxtkZiNnUVFFh9RJLmoiQSne+w==}
     cpu: [x64]
     os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.66.0':
     resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxlint/binding-android-arm-eabi@1.67.0':
-    resolution: {integrity: sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxlint/binding-android-arm-eabi@1.68.0':
-    resolution: {integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
@@ -755,32 +719,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.67.0':
-    resolution: {integrity: sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxlint/binding-android-arm64@1.68.0':
-    resolution: {integrity: sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@oxlint/binding-darwin-arm64@1.66.0':
     resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxlint/binding-darwin-arm64@1.67.0':
-    resolution: {integrity: sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxlint/binding-darwin-arm64@1.68.0':
-    resolution: {integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -791,32 +731,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.67.0':
-    resolution: {integrity: sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxlint/binding-darwin-x64@1.68.0':
-    resolution: {integrity: sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
   '@oxlint/binding-freebsd-x64@1.66.0':
     resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxlint/binding-freebsd-x64@1.67.0':
-    resolution: {integrity: sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxlint/binding-freebsd-x64@1.68.0':
-    resolution: {integrity: sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -827,52 +743,14 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
-    resolution: {integrity: sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
-    resolution: {integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@oxlint/binding-linux-arm-musleabihf@1.66.0':
     resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.67.0':
-    resolution: {integrity: sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
-    resolution: {integrity: sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@oxlint/binding-linux-arm64-gnu@1.66.0':
     resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-arm64-gnu@1.67.0':
-    resolution: {integrity: sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-arm64-gnu@1.68.0':
-    resolution: {integrity: sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -885,36 +763,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-arm64-musl@1.67.0':
-    resolution: {integrity: sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxlint/binding-linux-arm64-musl@1.68.0':
-    resolution: {integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@oxlint/binding-linux-ppc64-gnu@1.66.0':
     resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-ppc64-gnu@1.67.0':
-    resolution: {integrity: sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
-    resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -927,36 +777,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.67.0':
-    resolution: {integrity: sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
-    resolution: {integrity: sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-riscv64-musl@1.66.0':
     resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxlint/binding-linux-riscv64-musl@1.67.0':
-    resolution: {integrity: sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxlint/binding-linux-riscv64-musl@1.68.0':
-    resolution: {integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -969,36 +791,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-s390x-gnu@1.67.0':
-    resolution: {integrity: sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-s390x-gnu@1.68.0':
-    resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxlint/binding-linux-x64-gnu@1.66.0':
     resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-x64-gnu@1.67.0':
-    resolution: {integrity: sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxlint/binding-linux-x64-gnu@1.68.0':
-    resolution: {integrity: sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1011,34 +805,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-x64-musl@1.67.0':
-    resolution: {integrity: sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxlint/binding-linux-x64-musl@1.68.0':
-    resolution: {integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@oxlint/binding-openharmony-arm64@1.66.0':
     resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxlint/binding-openharmony-arm64@1.67.0':
-    resolution: {integrity: sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxlint/binding-openharmony-arm64@1.68.0':
-    resolution: {integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1049,50 +817,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-arm64-msvc@1.67.0':
-    resolution: {integrity: sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxlint/binding-win32-arm64-msvc@1.68.0':
-    resolution: {integrity: sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@oxlint/binding-win32-ia32-msvc@1.66.0':
     resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.67.0':
-    resolution: {integrity: sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxlint/binding-win32-ia32-msvc@1.68.0':
-    resolution: {integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@oxlint/binding-win32-x64-msvc@1.66.0':
     resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxlint/binding-win32-x64-msvc@1.67.0':
-    resolution: {integrity: sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxlint/binding-win32-x64-msvc@1.68.0':
-    resolution: {integrity: sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1249,44 +981,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@secretlint/config-creator@13.0.2':
-    resolution: {integrity: sha512-wEHE/x7jeaWnDqVhzUg3qLsnl3NOQTA2fVnxwc0Z7dn3SOSh5sEKFr6xTp/LhZxyuHnKJltlcF085UDUFOoqYQ==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/config-loader@13.0.2':
-    resolution: {integrity: sha512-r0ZVJ3oGUwWqoFPwhR9RK/fnp358TImaa72UhrBdBiuzMvAcPtE6EbnAYhbj0Yr5QS6ns+GI11jV344MLqkhTg==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/core@13.0.2':
-    resolution: {integrity: sha512-15vg+zCmjQuDFVoOPNt0TyEu0Z95eir2MO19++wG82yM/vbPtFu/m9qd6oh54ZOBXgMcchdGDTxMwJNDnCLxcA==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/formatter@13.0.2':
-    resolution: {integrity: sha512-DoU+aEsqPQxiWTQBNkTvQDmGTWB+TQS4UC6XEliWYv4KHpMV81O52jOE7XKS7QUoDMD4dbjh5wUTAgNO1dpzEg==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/node@13.0.2':
-    resolution: {integrity: sha512-xAK+0INjjMASH5guHLSozl++6kDyeOTy4FNC6dhPA7ieebCmHe/+QiAsr4KP9yDRZoh/uRmEno2NMDy5lgQpkA==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/profiler@13.0.2':
-    resolution: {integrity: sha512-vGaLZCoi9KewOF+sM0iIEBviWaH9mls1HmQFBgEPq4fnvmVO4PfKIkVr4CcAFm3Msg4NjzFE2RBAGwRR+5HEmQ==}
-
-  '@secretlint/resolver@13.0.2':
-    resolution: {integrity: sha512-Ko50V0P3YAtEO20xBTczOzguBVk6+taSqkoAPHoOSdsTsSq1gzeYggY1UC8vVEHPGyRp/mb2QOuwIShdJZ8JFg==}
-
-  '@secretlint/source-creator@13.0.2':
-    resolution: {integrity: sha512-tSooHad8QL+lqHP88zH9F8GMoR7bHUqPja5M/QnNHGnvOq/8OT1V8t1uigm6jlD03oJWNLwwF8QeHIedWKJ13g==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/types@13.0.2':
-    resolution: {integrity: sha512-cAZjr6ZTKgSuJMLyTGDrUEtK3XEZa+JStIkD+DmdkT32VGAN+dQJiYr1So3XJopsKSrqhP5kjZKT8WWtftZIpQ==}
-    engines: {node: '>=22.0.0'}
-
-  '@secretlint/walker@13.0.2':
-    resolution: {integrity: sha512-9GtWeTb763Ilr/nbRzdFidfZTBtbNEsz/BKrilgqLpKR9EqSWe9eYWDQaLIYb4PddIhwOgHuahRrX2BYATNcLQ==}
-    engines: {node: '>=22.0.0'}
-
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
 
@@ -1313,21 +1007,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@textlint/ast-node-types@15.7.0':
-    resolution: {integrity: sha512-wZILFXsRf2gGK9k0Fr69GUdfuZV9CrtByga8Qkw0CLyKBBfZXdNQlJF2XdZ2Ju9ggrTbAWehGo0RjCsAHSBWtA==}
-
-  '@textlint/linter-formatter@15.7.0':
-    resolution: {integrity: sha512-wrpDID1bfBt5XIUXtgw8NmGIuRFansWAtX1FLHv/zLRt3sgxCFnyon88SbhPOPITEgIlfFcsESElCSLzWySubQ==}
-
-  '@textlint/module-interop@15.7.0':
-    resolution: {integrity: sha512-+VdoeGFH66OasijhoO7D3OSrqTfJNAIH2OoQHEc5StlO0dqDO2JfZStCbuBPP/ZbpJvuYdoERBP+nKqTAT24vA==}
-
-  '@textlint/resolver@15.7.0':
-    resolution: {integrity: sha512-f94t/8ZR97uhOu2KvBujMGGtfdoJQZLjDNN7+7PNLaTjCtGn+XrqKjSP9lzXgBhUbKSygRN8AlrCMx9S70FHKw==}
-
-  '@textlint/types@15.7.0':
-    resolution: {integrity: sha512-soItNoFZ8Ua4WCgWwOaTEEyTkX7bjArwVxhN1F2UySeqPsP8QeRiKNUjAIfWQFHddTY6UYR1sHaEh+O0sQPv0Q==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -1371,9 +1050,6 @@ packages:
   '@types/node@24.10.15':
     resolution: {integrity: sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==}
 
-  '@types/normalize-package-data@2.4.4':
-    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1399,13 +1075,6 @@ packages:
     resolution: {integrity: sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/rule-tester@8.60.1':
-    resolution: {integrity: sha512-ly/WFKd5EwhTpuFbgQ81Z+67o4DRnlgKy+yHTuHWTy/u8yb0nEVPjDKqVUkJ1545vX2aAW1TELNSPPs+AOC+KA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/scope-manager@8.60.1':
@@ -1446,50 +1115,50 @@ packages:
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-ZGs+yhsPWFDkSHydJyF8I3d4witpXiD69auWZtSotNWG3gBR5Ne291m38rvxoLFDRlFHwAQpPT7q3yStp+cQSQ==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-RWhsFuzf26MXZOCppITm7Vg3ouR0bxA9O6Q9zRJMk/feyuGUFwO1V9qxX3DgiONatHmHKNR6+sBZNpnSbeCNGA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-cxmBCl1+fvGgom2vwPTbZ43bW68rfjDIU1ZDQGtjXvj1bpW9fEozskJqgZdNNHu8WQIl17zj4Ke+noENwgGu9w==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-V+8gKoi/pT5y6wsGzhs4MXL3YpPRaOri0U9/5++E9eqJtcbsUFMsEB3cykvBfzfGN7MtJxzNl1PQ8xudoyADeg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-/JPrQqa36CSMdXeEXhZ0mYUmufehIL8ujagXvU8z/3/b/CeWjgoZLJCuy76k9NLZCG7wGvcFWFK5kgOEKyDQdw==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-aBsfW6gq45WKSvyvnI3hgoW3ARHFHP+/BttGhob9n3wWx7SF7ALJdQ9lb7XKK0OVDyd8o3g3/DgYizc26DlWuw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-tWFLuzAWg8XnOkN7f94MAW8qLTMG7Q74IXHSG18cVmftuBxwvn1Lov+0Rnd9rsH7VAuSIu00Co6G3/PbGvGrxA==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-FHVd7C2ogrMRcUj3KWc6R9VYU6x+FUll7I5fvJKHE8e8UtzpmkxmLH18uaOFMwoFQmSMqAZOcnGlgtRDSe/vqw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-QfVLSH1NMAOa+N6Ey9cFHWppLFISOeCG3c0nJER3LXrDwkE4WtsVGHQ4IRDpIYT3Q2iC7QWUFWwrHayNKlrGYA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-U8CF9xzmNRAq9KfI2DrUlhylBDBoUNN3JK+B8fGoL4yl56/1/OSv/nAc3zQy9o65c7pUtbK5mJ7UsHsEfY/3VA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-DvpbX0aPCWCe4bJEP0cOky4cCwF+5QJZHsLoGV4gYd+0EFEkarTOxZG0CezP30E/iX6u1RUOrtTeMZOQthqDpQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-hjjyWSDlfUi6Ie9S7Uu+jQxzM0ZwzH8enaZ8uDy3/ntKfCizNHvC4vv1RNbLC6IW28A0LINr/s9ZmWXxYNgVmA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-J9nQB87sU+YJE3fq3XKwQvgLNWVXiEWyOP1L/FuyOlHb77UkFXmpaUbFTJ1w7rfd91nlKb2EECfsdTxbELUT0Q==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-Itbj6PB/FHisZuaDYJnmwKgbjd3EWuOyBsVUqakQR+BIEYuNdrmbf6ocxaPO0RZrGMLbrV12AE5/EZC+vqYN/w==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260608.1':
-    resolution: {integrity: sha512-nJyuPQwFn/VlP7JvFA0jPHJMMHaDy5vWM5xRYUwjZZd3dcY7LldfZ1EkdPOLc+GW0trXcmvRemQ4XCsBkOGOUQ==}
+  '@typescript/native-preview@7.0.0-dev.20260516.1':
+    resolution: {integrity: sha512-mRzRdR9whPRzkLcGk1+wa15/jlIAFMyYV3X9A5+zHQiPR0ZZl1ywSHNtPa/OZmba3Mzsu9jIIFLmPIsryVt3aQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1756,20 +1425,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1784,10 +1442,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
 
   aws-cdk-lib@2.258.0:
     resolution: {integrity: sha512-OfFfg30ikBRJ3dimlzsWhPIrj6qug1p2XYsdB38CtMtcur7SufzoUczgI6kWjbQkOVcQgYzhzN29DErV0yZG7A==}
@@ -1815,15 +1469,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  binaryextensions@6.11.0:
-    resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
-    engines: {node: '>=4'}
-
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
-
-  boundary@2.0.0:
-    resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1831,14 +1478,6 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
-
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1903,10 +1542,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  editions@6.22.0:
-    resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
-    engines: {ecmascript: '>= es5', node: '>=4'}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1917,10 +1552,6 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
-
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -2008,9 +1639,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
-
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
 
@@ -2062,14 +1690,6 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-
-  has-flag@5.0.1:
-    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
-    engines: {node: '>=12'}
-
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -2078,10 +1698,6 @@ packages:
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
-
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -2097,10 +1713,6 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-
-  index-to-position@1.2.0:
-    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
-    engines: {node: '>=18'}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -2125,23 +1737,12 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  istextorbinary@9.5.0:
-    resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
-    engines: {node: '>=4'}
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2150,16 +1751,8 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2253,21 +1846,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  lru-cache@11.3.6:
-    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
-    engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2396,10 +1976,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  normalize-package-data@8.0.0:
-    resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
@@ -2431,8 +2007,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-tsgolint@0.23.0:
-    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+  oxlint-tsgolint@0.22.0:
+    resolution: {integrity: sha512-ku4MecLmCQIj1ScCtzNAqTuyl0BJQ02B36fJT+c5XQihHpYSFak+FC3GYO5fPyYk4oDwi0w0S7hTvrpNzuZhig==}
     hasBin: true
 
   oxlint@1.66.0:
@@ -2440,35 +2016,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
+      oxlint-tsgolint: 0.22.0
     peerDependenciesMeta:
       oxlint-tsgolint:
-        optional: true
-
-  oxlint@1.67.0:
-    resolution: {integrity: sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
-      vite-plus: '*'
-    peerDependenciesMeta:
-      oxlint-tsgolint:
-        optional: true
-      vite-plus:
-        optional: true
-
-  oxlint@1.68.0:
-    resolution: {integrity: sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      oxlint-tsgolint: '>=0.22.1'
-      vite-plus: '*'
-    peerDependenciesMeta:
-      oxlint-tsgolint:
-        optional: true
-      vite-plus:
         optional: true
 
   p-limit@3.1.0:
@@ -2478,14 +2028,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
-
-  parse-json@8.3.0:
-    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
-    engines: {node: '>=18'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2511,13 +2053,6 @@ packages:
   pixelmatch@7.2.0:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
-
-  pluralize@2.0.0:
-    resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
-
-  pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
-    engines: {node: '>=4'}
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -2546,13 +2081,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  rc-config-loader@4.1.4:
-    resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
-
-  read-pkg@10.1.0:
-    resolution: {integrity: sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==}
-    engines: {node: '>=20'}
-
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -2578,18 +2106,9 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   rollup@4.61.1:
     resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
-  secretlint@13.0.2:
-    resolution: {integrity: sha512-veYNpVC+Yw9H/EWzdGyEsYHqCFXgKOinGEMbRffvnkHoWnE0CongrCnWXZJ1bkYmirlhemq/gkiOZ5zdHcHCQg==}
-    engines: {node: '>=22.0.0'}
     hasBin: true
 
   section-matter@1.0.0:
@@ -2616,28 +2135,12 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
-  slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
-
-  spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
-
-  spdx-exceptions@2.5.0:
-    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-
-  spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
-
-  spdx-license-ids@3.0.23:
-    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -2656,50 +2159,12 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
-
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  structured-source@4.0.0:
-    resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
-
-  supports-color@10.2.2:
-    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
-    engines: {node: '>=18'}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-
-  supports-hyperlinks@4.4.0:
-    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
-    engines: {node: '>=20'}
-
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
-
-  table@6.9.0:
-    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
-    engines: {node: '>=10.0.0'}
-
-  tagged-tag@1.0.0:
-    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
-    engines: {node: '>=20'}
-
-  terminal-link@5.0.0:
-    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
-    engines: {node: '>=20'}
-
-  text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
-  textextensions@6.11.0:
-    resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
-    engines: {node: '>=4'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2742,25 +2207,12 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
-
-  type-fest@5.6.0:
-    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
-    engines: {node: '>=20'}
-
   typescript-eslint@8.60.1:
     resolution: {integrity: sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
-
-  typescript@6.0.0-dev.20260416:
-    resolution: {integrity: sha512-64CCow5rQc6+oBAPqLtvZ8f3iz4WVCLwMVkg6/kOfMQlGshVOMkBhCXn+MMP4SX4Xtnz48VpD98FkptirMEuEQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -2772,10 +2224,6 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  unicorn-magic@0.4.0:
-    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
-    engines: {node: '>=20'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2800,13 +2248,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
-
-  version-range@4.15.0:
-    resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
-    engines: {node: '>=4'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2943,21 +2384,7 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@54.2.0': {}
 
-  '@azu/format-text@1.0.2': {}
-
-  '@azu/style-format@1.0.1':
-    dependencies:
-      '@azu/format-text': 1.0.2
-
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -3295,193 +2722,79 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.52.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+  '@oxlint-tsgolint/darwin-arm64@0.22.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
+  '@oxlint-tsgolint/darwin-x64@0.22.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
+  '@oxlint-tsgolint/linux-arm64@0.22.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
+  '@oxlint-tsgolint/linux-x64@0.22.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
+  '@oxlint-tsgolint/win32-arm64@0.22.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
+  '@oxlint-tsgolint/win32-x64@0.22.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.66.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.67.0':
-    optional: true
-
-  '@oxlint/binding-android-arm-eabi@1.68.0':
-    optional: true
-
   '@oxlint/binding-android-arm64@1.66.0':
-    optional: true
-
-  '@oxlint/binding-android-arm64@1.67.0':
-    optional: true
-
-  '@oxlint/binding-android-arm64@1.68.0':
     optional: true
 
   '@oxlint/binding-darwin-arm64@1.66.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.67.0':
-    optional: true
-
-  '@oxlint/binding-darwin-arm64@1.68.0':
-    optional: true
-
   '@oxlint/binding-darwin-x64@1.66.0':
-    optional: true
-
-  '@oxlint/binding-darwin-x64@1.67.0':
-    optional: true
-
-  '@oxlint/binding-darwin-x64@1.68.0':
     optional: true
 
   '@oxlint/binding-freebsd-x64@1.66.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.67.0':
-    optional: true
-
-  '@oxlint/binding-freebsd-x64@1.68.0':
-    optional: true
-
   '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
     optional: true
 
   '@oxlint/binding-linux-arm-musleabihf@1.66.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm-musleabihf@1.68.0':
-    optional: true
-
   '@oxlint/binding-linux-arm64-gnu@1.66.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm64-gnu@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm64-gnu@1.68.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-musl@1.66.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-arm64-musl@1.68.0':
-    optional: true
-
   '@oxlint/binding-linux-ppc64-gnu@1.66.0':
-    optional: true
-
-  '@oxlint/binding-linux-ppc64-gnu@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-ppc64-gnu@1.68.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-gnu@1.66.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-riscv64-gnu@1.68.0':
-    optional: true
-
   '@oxlint/binding-linux-riscv64-musl@1.66.0':
-    optional: true
-
-  '@oxlint/binding-linux-riscv64-musl@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-riscv64-musl@1.68.0':
     optional: true
 
   '@oxlint/binding-linux-s390x-gnu@1.66.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-s390x-gnu@1.68.0':
-    optional: true
-
   '@oxlint/binding-linux-x64-gnu@1.66.0':
-    optional: true
-
-  '@oxlint/binding-linux-x64-gnu@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-x64-gnu@1.68.0':
     optional: true
 
   '@oxlint/binding-linux-x64-musl@1.66.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.67.0':
-    optional: true
-
-  '@oxlint/binding-linux-x64-musl@1.68.0':
-    optional: true
-
   '@oxlint/binding-openharmony-arm64@1.66.0':
-    optional: true
-
-  '@oxlint/binding-openharmony-arm64@1.67.0':
-    optional: true
-
-  '@oxlint/binding-openharmony-arm64@1.68.0':
     optional: true
 
   '@oxlint/binding-win32-arm64-msvc@1.66.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.67.0':
-    optional: true
-
-  '@oxlint/binding-win32-arm64-msvc@1.68.0':
-    optional: true
-
   '@oxlint/binding-win32-ia32-msvc@1.66.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.67.0':
-    optional: true
-
-  '@oxlint/binding-win32-ia32-msvc@1.68.0':
-    optional: true
-
   '@oxlint/binding-win32-x64-msvc@1.66.0':
-    optional: true
-
-  '@oxlint/binding-win32-x64-msvc@1.67.0':
-    optional: true
-
-  '@oxlint/binding-win32-x64-msvc@1.68.0':
     optional: true
 
   '@oxlint/plugins@1.61.0': {}
@@ -3567,75 +2880,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
-  '@secretlint/config-creator@13.0.2':
-    dependencies:
-      '@secretlint/types': 13.0.2
-
-  '@secretlint/config-loader@13.0.2':
-    dependencies:
-      '@secretlint/profiler': 13.0.2
-      '@secretlint/resolver': 13.0.2
-      '@secretlint/types': 13.0.2
-      ajv: 8.20.0
-      debug: 4.4.3
-      rc-config-loader: 4.1.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/core@13.0.2':
-    dependencies:
-      '@secretlint/profiler': 13.0.2
-      '@secretlint/types': 13.0.2
-      debug: 4.4.3
-      structured-source: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/formatter@13.0.2':
-    dependencies:
-      '@secretlint/resolver': 13.0.2
-      '@secretlint/types': 13.0.2
-      '@textlint/linter-formatter': 15.7.0
-      '@textlint/module-interop': 15.7.0
-      '@textlint/types': 15.7.0
-      chalk: 5.6.2
-      debug: 4.4.3
-      pluralize: 8.0.0
-      strip-ansi: 7.2.0
-      table: 6.9.0
-      terminal-link: 5.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/node@13.0.2':
-    dependencies:
-      '@secretlint/config-loader': 13.0.2
-      '@secretlint/core': 13.0.2
-      '@secretlint/formatter': 13.0.2
-      '@secretlint/profiler': 13.0.2
-      '@secretlint/source-creator': 13.0.2
-      '@secretlint/types': 13.0.2
-      debug: 4.4.3
-      p-map: 7.0.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/profiler@13.0.2': {}
-
-  '@secretlint/resolver@13.0.2': {}
-
-  '@secretlint/source-creator@13.0.2':
-    dependencies:
-      '@secretlint/types': 13.0.2
-      istextorbinary: 9.5.0
-
-  '@secretlint/types@13.0.2': {}
-
-  '@secretlint/walker@13.0.2':
-    dependencies:
-      ignore: 7.0.5
-      picomatch: 4.0.4
-
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -3675,35 +2919,6 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@textlint/ast-node-types@15.7.0': {}
-
-  '@textlint/linter-formatter@15.7.0':
-    dependencies:
-      '@azu/format-text': 1.0.2
-      '@azu/style-format': 1.0.1
-      '@textlint/module-interop': 15.7.0
-      '@textlint/resolver': 15.7.0
-      '@textlint/types': 15.7.0
-      chalk: 4.1.2
-      debug: 4.4.3
-      js-yaml: 4.1.1
-      lodash: 4.18.1
-      pluralize: 2.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      table: 6.9.0
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@textlint/module-interop@15.7.0': {}
-
-  '@textlint/resolver@15.7.0': {}
-
-  '@textlint/types@15.7.0':
-    dependencies:
-      '@textlint/ast-node-types': 15.7.0
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -3750,32 +2965,14 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/normalize-package-data@2.4.4': {}
-
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/visitor-keys': 8.60.1
-      eslint: 10.4.1(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.0-dev.20260416)
-      typescript: 6.0.0-dev.20260416
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
@@ -3785,18 +2982,6 @@ snapshots:
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/visitor-keys': 8.60.1
-      debug: 4.4.3
-      eslint: 10.4.1(jiti@2.6.1)
-      typescript: 6.0.0-dev.20260416
     transitivePeerDependencies:
       - supports-color
 
@@ -3812,15 +2997,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.60.1(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/types': 8.60.1
-      debug: 4.4.3
-      typescript: 6.0.0-dev.20260416
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
@@ -3830,44 +3006,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      ajv: 6.15.0
-      eslint: 10.4.1(jiti@2.6.1)
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      semver: 7.8.2
-      typescript: 6.0.0-dev.20260416
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@8.60.1':
     dependencies:
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/visitor-keys': 8.60.1
 
-  '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      typescript: 6.0.0-dev.20260416
-
   '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
-
-  '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      debug: 4.4.3
-      eslint: 10.4.1(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@6.0.0-dev.20260416)
-      typescript: 6.0.0-dev.20260416
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
@@ -3883,21 +3029,6 @@ snapshots:
 
   '@typescript-eslint/types@8.60.1': {}
 
-  '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/visitor-keys': 8.60.1
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.8.2
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.0-dev.20260416)
-      typescript: 6.0.0-dev.20260416
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.60.1(typescript@6.0.3)
@@ -3910,17 +3041,6 @@ snapshots:
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/types': 8.60.1
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
-      eslint: 10.4.1(jiti@2.6.1)
-      typescript: 6.0.0-dev.20260416
     transitivePeerDependencies:
       - supports-color
 
@@ -3940,36 +3060,36 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260608.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260516.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260608.1':
+  '@typescript/native-preview@7.0.0-dev.20260516.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260608.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260516.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260516.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260516.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260516.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260516.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260516.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260516.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -3978,19 +3098,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)'
       vue: 3.5.35(typescript@6.0.3)
-
-  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)':
-    dependencies:
-      '@oxc-project/runtime': 0.133.0
-      '@oxc-project/types': 0.133.0
-      lightningcss: 1.32.0
-      postcss: 8.5.15
-    optionalDependencies:
-      '@types/node': 24.10.15
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      typescript: 6.0.0-dev.20260416
-      yaml: 2.8.1
 
   '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)':
     dependencies:
@@ -4022,46 +3129,6 @@ snapshots:
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
-
-  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)
-      es-module-lexer: 1.7.0
-      obug: 2.1.2
-      pixelmatch: 7.2.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      vite: 7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
-      ws: 8.21.0
-    optionalDependencies:
-      '@types/node': 24.10.15
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@vitejs/devtools'
-      - bufferutil
-      - esbuild
-      - jiti
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - yaml
 
   '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)':
     dependencies:
@@ -4102,7 +3169,6 @@ snapshots:
       - unrun
       - utf-8-validate
       - yaml
-    optional: true
 
   '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.24':
     optional: true
@@ -4211,20 +3277,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
   ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -4238,8 +3291,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astral-regex@2.0.0: {}
-
   aws-cdk-lib@2.258.0(constructs@10.6.0):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.282
@@ -4251,26 +3302,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  binaryextensions@6.11.0:
-    dependencies:
-      editions: 6.22.0
-
   birpc@2.9.0: {}
-
-  boundary@2.0.0: {}
 
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
   ccount@2.0.1: {}
-
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
-  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -4294,11 +3332,11 @@ snapshots:
 
   constructs@10.6.0: {}
 
-  corsa-oxlint@0.43.0(oxlint-tsgolint@0.23.0):
+  corsa-oxlint@0.43.0(oxlint-tsgolint@0.22.0):
     dependencies:
       '@corsa-bind/napi': 0.43.0
       '@oxlint/plugins': 1.66.0
-      oxlint: 1.66.0(oxlint-tsgolint@0.23.0)
+      oxlint: 1.66.0(oxlint-tsgolint@0.22.0)
     transitivePeerDependencies:
       - oxlint-tsgolint
 
@@ -4328,17 +3366,11 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  editions@6.22.0:
-    dependencies:
-      version-range: 4.15.0
-
   emoji-regex@8.0.0: {}
 
   entities@4.5.0: {}
 
   entities@7.0.1: {}
-
-  environment@1.1.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -4459,8 +3491,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
-
   fault@2.0.1:
     dependencies:
       format: 0.2.2
@@ -4507,10 +3537,6 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  has-flag@4.0.0: {}
-
-  has-flag@5.0.1: {}
-
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -4531,10 +3557,6 @@ snapshots:
 
   hookable@5.5.3: {}
 
-  hosted-git-info@9.0.3:
-    dependencies:
-      lru-cache: 11.3.6
-
   html-void-elements@3.0.0: {}
 
   ignore@5.3.2: {}
@@ -4542,8 +3564,6 @@ snapshots:
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
-
-  index-to-position@1.2.0: {}
 
   is-extendable@0.1.1: {}
 
@@ -4559,35 +3579,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  istextorbinary@9.5.0:
-    dependencies:
-      binaryextensions: 6.11.0
-      editions: 6.22.0
-      textextensions: 6.11.0
-
   jiti@2.6.1:
     optional: true
-
-  js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
-
-  json5@2.2.3: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4657,15 +3661,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.merge@4.6.2: {}
-
-  lodash.truncate@4.4.2: {}
-
-  lodash@4.18.1: {}
-
   longest-streak@3.1.0: {}
-
-  lru-cache@11.3.6: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4905,12 +3901,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  normalize-package-data@8.0.0:
-    dependencies:
-      hosted-git-info: 9.0.3
-      semver: 7.8.2
-      validate-npm-package-license: 3.0.4
-
   obug@2.1.2: {}
 
   oniguruma-parser@0.12.2: {}
@@ -4953,31 +3943,6 @@ snapshots:
       '@oxc-minify/binding-win32-ia32-msvc': 0.134.0
       '@oxc-minify/binding-win32-x64-msvc': 0.134.0
 
-  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.52.0
-      '@oxfmt/binding-android-arm64': 0.52.0
-      '@oxfmt/binding-darwin-arm64': 0.52.0
-      '@oxfmt/binding-darwin-x64': 0.52.0
-      '@oxfmt/binding-freebsd-x64': 0.52.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
-      '@oxfmt/binding-linux-arm64-musl': 0.52.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
-      '@oxfmt/binding-linux-x64-gnu': 0.52.0
-      '@oxfmt/binding-linux-x64-musl': 0.52.0
-      '@oxfmt/binding-openharmony-arm64': 0.52.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
-      '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
-
   oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
     dependencies:
       tinypool: 2.1.0
@@ -5002,18 +3967,17 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
       vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
-    optional: true
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.22.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.23.0
-      '@oxlint-tsgolint/darwin-x64': 0.23.0
-      '@oxlint-tsgolint/linux-arm64': 0.23.0
-      '@oxlint-tsgolint/linux-x64': 0.23.0
-      '@oxlint-tsgolint/win32-arm64': 0.23.0
-      '@oxlint-tsgolint/win32-x64': 0.23.0
+      '@oxlint-tsgolint/darwin-arm64': 0.22.0
+      '@oxlint-tsgolint/darwin-x64': 0.22.0
+      '@oxlint-tsgolint/linux-arm64': 0.22.0
+      '@oxlint-tsgolint/linux-x64': 0.22.0
+      '@oxlint-tsgolint/win32-arm64': 0.22.0
+      '@oxlint-tsgolint/win32-x64': 0.22.0
 
-  oxlint@1.66.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.66.0(oxlint-tsgolint@0.22.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.66.0
       '@oxlint/binding-android-arm64': 1.66.0
@@ -5034,80 +3998,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.66.0
       '@oxlint/binding-win32-ia32-msvc': 1.66.0
       '@oxlint/binding-win32-x64-msvc': 1.66.0
-      oxlint-tsgolint: 0.23.0
-
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.67.0
-      '@oxlint/binding-android-arm64': 1.67.0
-      '@oxlint/binding-darwin-arm64': 1.67.0
-      '@oxlint/binding-darwin-x64': 1.67.0
-      '@oxlint/binding-freebsd-x64': 1.67.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
-      '@oxlint/binding-linux-arm64-gnu': 1.67.0
-      '@oxlint/binding-linux-arm64-musl': 1.67.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
-      '@oxlint/binding-linux-riscv64-musl': 1.67.0
-      '@oxlint/binding-linux-s390x-gnu': 1.67.0
-      '@oxlint/binding-linux-x64-gnu': 1.67.0
-      '@oxlint/binding-linux-x64-musl': 1.67.0
-      '@oxlint/binding-openharmony-arm64': 1.67.0
-      '@oxlint/binding-win32-arm64-msvc': 1.67.0
-      '@oxlint/binding-win32-ia32-msvc': 1.67.0
-      '@oxlint/binding-win32-x64-msvc': 1.67.0
-      oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
-
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.67.0
-      '@oxlint/binding-android-arm64': 1.67.0
-      '@oxlint/binding-darwin-arm64': 1.67.0
-      '@oxlint/binding-darwin-x64': 1.67.0
-      '@oxlint/binding-freebsd-x64': 1.67.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
-      '@oxlint/binding-linux-arm64-gnu': 1.67.0
-      '@oxlint/binding-linux-arm64-musl': 1.67.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
-      '@oxlint/binding-linux-riscv64-musl': 1.67.0
-      '@oxlint/binding-linux-s390x-gnu': 1.67.0
-      '@oxlint/binding-linux-x64-gnu': 1.67.0
-      '@oxlint/binding-linux-x64-musl': 1.67.0
-      '@oxlint/binding-openharmony-arm64': 1.67.0
-      '@oxlint/binding-win32-arm64-msvc': 1.67.0
-      '@oxlint/binding-win32-ia32-msvc': 1.67.0
-      '@oxlint/binding-win32-x64-msvc': 1.67.0
-      oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
-    optional: true
-
-  oxlint@1.68.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.68.0
-      '@oxlint/binding-android-arm64': 1.68.0
-      '@oxlint/binding-darwin-arm64': 1.68.0
-      '@oxlint/binding-darwin-x64': 1.68.0
-      '@oxlint/binding-freebsd-x64': 1.68.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.68.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.68.0
-      '@oxlint/binding-linux-arm64-gnu': 1.68.0
-      '@oxlint/binding-linux-arm64-musl': 1.68.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.68.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.68.0
-      '@oxlint/binding-linux-riscv64-musl': 1.68.0
-      '@oxlint/binding-linux-s390x-gnu': 1.68.0
-      '@oxlint/binding-linux-x64-gnu': 1.68.0
-      '@oxlint/binding-linux-x64-musl': 1.68.0
-      '@oxlint/binding-openharmony-arm64': 1.68.0
-      '@oxlint/binding-win32-arm64-msvc': 1.68.0
-      '@oxlint/binding-win32-ia32-msvc': 1.68.0
-      '@oxlint/binding-win32-x64-msvc': 1.68.0
-      oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+      oxlint-tsgolint: 0.22.0
 
   p-limit@3.1.0:
     dependencies:
@@ -5116,14 +4007,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-map@7.0.4: {}
-
-  parse-json@8.3.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      index-to-position: 1.2.0
-      type-fest: 4.41.0
 
   path-exists@4.0.0: {}
 
@@ -5140,10 +4023,6 @@ snapshots:
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
-
-  pluralize@2.0.0: {}
-
-  pluralize@8.0.0: {}
 
   pngjs@7.0.0: {}
 
@@ -5162,23 +4041,6 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
-
-  rc-config-loader@4.1.4:
-    dependencies:
-      debug: 4.4.3
-      js-yaml: 4.1.1
-      json5: 2.2.3
-      require-from-string: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  read-pkg@10.1.0:
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-      normalize-package-data: 8.0.0
-      parse-json: 8.3.0
-      type-fest: 5.6.0
-      unicorn-magic: 0.4.0
 
   regex-recursion@6.0.2:
     dependencies:
@@ -5225,8 +4087,6 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2: {}
-
   rollup@4.61.1:
     dependencies:
       '@types/estree': 1.0.9
@@ -5258,19 +4118,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
-  secretlint@13.0.2:
-    dependencies:
-      '@secretlint/config-creator': 13.0.2
-      '@secretlint/formatter': 13.0.2
-      '@secretlint/node': 13.0.2
-      '@secretlint/profiler': 13.0.2
-      '@secretlint/resolver': 13.0.2
-      '@secretlint/walker': 13.0.2
-      debug: 4.4.3
-      read-pkg: 10.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   section-matter@1.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -5301,29 +4148,9 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
-  slice-ansi@4.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
-
-  spdx-correct@3.2.0:
-    dependencies:
-      spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.23
-
-  spdx-exceptions@2.5.0: {}
-
-  spdx-expression-parse@3.0.1:
-    dependencies:
-      spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.23
-
-  spdx-license-ids@3.0.23: {}
 
   sprintf-js@1.0.3: {}
 
@@ -5344,49 +4171,9 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   strip-bom-string@1.0.0: {}
 
-  structured-source@4.0.0:
-    dependencies:
-      boundary: 2.0.0
-
-  supports-color@10.2.2: {}
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
-  supports-hyperlinks@4.4.0:
-    dependencies:
-      has-flag: 5.0.1
-      supports-color: 10.2.2
-
   tabbable@6.4.0: {}
-
-  table@6.9.0:
-    dependencies:
-      ajv: 8.20.0
-      lodash.truncate: 4.4.2
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  tagged-tag@1.0.0: {}
-
-  terminal-link@5.0.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      supports-hyperlinks: 4.4.0
-
-  text-table@0.2.0: {}
-
-  textextensions@6.11.0:
-    dependencies:
-      editions: 6.22.0
 
   tinybench@2.9.0: {}
 
@@ -5407,10 +4194,6 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.0-dev.20260416):
-    dependencies:
-      typescript: 6.0.0-dev.20260416
-
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -5422,26 +4205,9 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@4.41.0: {}
-
-  type-fest@5.6.0:
-    dependencies:
-      tagged-tag: 1.0.0
-
-  typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
-      eslint: 10.4.1(jiti@2.6.1)
-      typescript: 6.0.0-dev.20260416
-    transitivePeerDependencies:
-      - supports-color
-
   typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
@@ -5450,15 +4216,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@6.0.0-dev.20260416: {}
-
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
   undici-types@7.16.0: {}
-
-  unicorn-magic@0.4.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5503,13 +4265,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  validate-npm-package-license@3.0.4:
-    dependencies:
-      spdx-correct: 3.2.0
-      spdx-expression-parse: 3.0.1
-
-  version-range@4.15.0: {}
-
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -5520,56 +4275,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1):
-    dependencies:
-      '@oxc-project/types': 0.133.0
-      '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
-      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
-      oxlint-tsgolint: 0.23.0
-    optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.24
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.24
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.24
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.24
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.24
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.24
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.24
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@types/node'
-      - '@vitejs/devtools'
-      - '@vitest/coverage-istanbul'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - bufferutil
-      - esbuild
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - svelte
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - vite
-      - yaml
-
   vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -5577,8 +4282,8 @@ snapshots:
       '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)
       '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
       oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
-      oxlint-tsgolint: 0.23.0
+      oxlint: 1.66.0(oxlint-tsgolint@0.22.0)
+      oxlint-tsgolint: 0.22.0
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
       '@voidzero-dev/vite-plus-darwin-x64': 0.1.24
@@ -5619,7 +4324,6 @@ snapshots:
       - utf-8-validate
       - vite
       - yaml
-    optional: true
 
   vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,16 +20,22 @@ importers:
         version: 24.10.15
       '@typescript-eslint/parser':
         specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
       '@typescript-eslint/rule-tester':
         specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
       '@typescript-eslint/utils':
         specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260608.1
+        version: 7.0.0-dev.20260608.1
       '@voidzero-dev/vite-plus-core':
         specifier: ^0.1.11
-        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)
+        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)
+      corsa-oxlint:
+        specifier: 0.43.0
+        version: 0.43.0(oxlint-tsgolint@0.23.0)
       eslint:
         specifier: ^10.0.0
         version: 10.4.1(jiti@2.6.1)
@@ -37,14 +43,14 @@ importers:
         specifier: ^13.0.0
         version: 13.0.2
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.3
+        specifier: 6.0.0-dev.20260416
+        version: 6.0.0-dev.20260416
       typescript-eslint:
         specifier: ^8.58.0
-        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
       vite-plus:
         specifier: ^0.1.11
-        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+        version: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
 
   docs:
     devDependencies:
@@ -134,6 +140,62 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@corsa-bind/napi-darwin-arm64@0.43.0':
+    resolution: {integrity: sha512-quhKndwH9wCPW5DRtDrxJWQ6rR36JszRLLn0uz3RDJyaH8paWdT2Zo1DnVXVpQhEf7KpG5FVbz6+IASBjgQTUw==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@corsa-bind/napi-darwin-x64@0.43.0':
+    resolution: {integrity: sha512-famOF2NJxPfMt3JbatScJuCsqX+Q8PAkC+NB0h/mbQa0j4bWaQMrhypwIyhltc+cS5brob0er5aGrvsIUouLkw==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@corsa-bind/napi-linux-arm64-gnu@0.43.0':
+    resolution: {integrity: sha512-YaeffMDMkLQ8y2iZ60DQ+RZfncD0lv1YILiNtsKrzVI2abMAp3+fe2LSSjIbX9xYayX9A2KtYX92x84nVs5Ugg==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@corsa-bind/napi-linux-arm64-musl@0.43.0':
+    resolution: {integrity: sha512-aw7NJFT2YLBH1/mnh9kvELoDemDfqlN3a83tybCfSeYbKmijeRO7B8hG2Fvs4cy0N3GOH6zvhz7hVmVpGxnYuA==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@corsa-bind/napi-linux-x64-gnu@0.43.0':
+    resolution: {integrity: sha512-Qn2+mvS8xu2e53eMTBipBJsmxDUsJ337S8iSqxUHBi2I0nyCVcfPn9vJoAMtACNh/0GNWrXlcSbiHSW6M4jnAw==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@corsa-bind/napi-linux-x64-musl@0.43.0':
+    resolution: {integrity: sha512-eDqrc7M3tQ5Y4J7Tb2fuGUdvsZiv5eRMmhxfVb2mwAi1cp37d3rzDOQqGZ0xyd7nzS/JcUoTv0u2mqSU2/23Bg==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@corsa-bind/napi-win32-arm64-msvc@0.43.0':
+    resolution: {integrity: sha512-t6YDE0aaazn1a0//tnsTU840AqvEfN+3u30E+A1gBP2RytsxlD3SS8pBSAP8/dCOaEy9z3y2PhZn+hrCmZw0pA==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@corsa-bind/napi-win32-x64-msvc@0.43.0':
+    resolution: {integrity: sha512-wK50/oHTMWnBO1Y7pRA9Lk8Y4zPvJKEOad6Us+CipHKV/cNLYs8evsA8EFq5BNKKHPBqZjA9Ynwhepq3yFvFmg==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
+    cpu: [x64]
+    os: [win32]
+
+  '@corsa-bind/napi@0.43.0':
+    resolution: {integrity: sha512-GFzzyS8vXJTF4qUoezZZMIpJQMg8ZCgE80cYPI14ayHeLVoUb8PYA05fap8fMP6I8CS0P9l4zydbAwxxibJOdw==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
 
   '@docsearch/css@4.6.3':
     resolution: {integrity: sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==}
@@ -669,6 +731,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint/binding-android-arm-eabi@1.66.0':
+    resolution: {integrity: sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxlint/binding-android-arm-eabi@1.67.0':
     resolution: {integrity: sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -679,6 +747,12 @@ packages:
     resolution: {integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.66.0':
+    resolution: {integrity: sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
 
   '@oxlint/binding-android-arm64@1.67.0':
@@ -693,6 +767,12 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxlint/binding-darwin-arm64@1.66.0':
+    resolution: {integrity: sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxlint/binding-darwin-arm64@1.67.0':
     resolution: {integrity: sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -703,6 +783,12 @@ packages:
     resolution: {integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.66.0':
+    resolution: {integrity: sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxlint/binding-darwin-x64@1.67.0':
@@ -717,6 +803,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxlint/binding-freebsd-x64@1.66.0':
+    resolution: {integrity: sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxlint/binding-freebsd-x64@1.67.0':
     resolution: {integrity: sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -729,6 +821,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
+    resolution: {integrity: sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
     resolution: {integrity: sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -737,6 +835,12 @@ packages:
 
   '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
     resolution: {integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+    resolution: {integrity: sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -753,6 +857,13 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxlint/binding-linux-arm64-gnu@1.66.0':
+    resolution: {integrity: sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-arm64-gnu@1.67.0':
     resolution: {integrity: sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -766,6 +877,13 @@ packages:
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.66.0':
+    resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-arm64-musl@1.67.0':
     resolution: {integrity: sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==}
@@ -781,6 +899,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
+    resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-ppc64-gnu@1.67.0':
     resolution: {integrity: sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -792,6 +917,13 @@ packages:
     resolution: {integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+    resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -809,6 +941,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-riscv64-musl@1.66.0':
+    resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-linux-riscv64-musl@1.67.0':
     resolution: {integrity: sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -823,6 +962,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+    resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxlint/binding-linux-s390x-gnu@1.67.0':
     resolution: {integrity: sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -834,6 +980,13 @@ packages:
     resolution: {integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.66.0':
+    resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -851,6 +1004,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxlint/binding-linux-x64-musl@1.66.0':
+    resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxlint/binding-linux-x64-musl@1.67.0':
     resolution: {integrity: sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -865,6 +1025,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxlint/binding-openharmony-arm64@1.66.0':
+    resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@oxlint/binding-openharmony-arm64@1.67.0':
     resolution: {integrity: sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -876,6 +1042,12 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+    resolution: {integrity: sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@oxlint/binding-win32-arm64-msvc@1.67.0':
     resolution: {integrity: sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==}
@@ -889,6 +1061,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+    resolution: {integrity: sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxlint/binding-win32-ia32-msvc@1.67.0':
     resolution: {integrity: sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -899,6 +1077,12 @@ packages:
     resolution: {integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.66.0':
+    resolution: {integrity: sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@oxlint/binding-win32-x64-msvc@1.67.0':
@@ -915,6 +1099,10 @@ packages:
 
   '@oxlint/plugins@1.61.0':
     resolution: {integrity: sha512-nkOyZEF1vH527CkdQtOp1HMrVFEM4ResURvI2JFeGoup+h+43J/k/FgdOR9b9Isxg+Yae7qVDa7y3nssE8b3TQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@oxlint/plugins@1.66.0':
+    resolution: {integrity: sha512-dVw9+y1tB9rDObtjzsDhxRsreZrEoKohujt+w/sZ09+kmA5yI/ORQJFPR/xSC+jpw0TWmE6gnb6N1lD/z7uElA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@polka/url@1.0.0-next.29':
@@ -1257,6 +1445,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.60.1':
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-ZGs+yhsPWFDkSHydJyF8I3d4witpXiD69auWZtSotNWG3gBR5Ne291m38rvxoLFDRlFHwAQpPT7q3yStp+cQSQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-cxmBCl1+fvGgom2vwPTbZ43bW68rfjDIU1ZDQGtjXvj1bpW9fEozskJqgZdNNHu8WQIl17zj4Ke+noENwgGu9w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-/JPrQqa36CSMdXeEXhZ0mYUmufehIL8ujagXvU8z/3/b/CeWjgoZLJCuy76k9NLZCG7wGvcFWFK5kgOEKyDQdw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-tWFLuzAWg8XnOkN7f94MAW8qLTMG7Q74IXHSG18cVmftuBxwvn1Lov+0Rnd9rsH7VAuSIu00Co6G3/PbGvGrxA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-QfVLSH1NMAOa+N6Ey9cFHWppLFISOeCG3c0nJER3LXrDwkE4WtsVGHQ4IRDpIYT3Q2iC7QWUFWwrHayNKlrGYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-DvpbX0aPCWCe4bJEP0cOky4cCwF+5QJZHsLoGV4gYd+0EFEkarTOxZG0CezP30E/iX6u1RUOrtTeMZOQthqDpQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-J9nQB87sU+YJE3fq3XKwQvgLNWVXiEWyOP1L/FuyOlHb77UkFXmpaUbFTJ1w7rfd91nlKb2EECfsdTxbELUT0Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260608.1':
+    resolution: {integrity: sha512-nJyuPQwFn/VlP7JvFA0jPHJMMHaDy5vWM5xRYUwjZZd3dcY7LldfZ1EkdPOLc+GW0trXcmvRemQ4XCsBkOGOUQ==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -1630,6 +1865,10 @@ packages:
 
   constructs@10.6.0:
     resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
+
+  corsa-oxlint@0.43.0:
+    resolution: {integrity: sha512-AJra+owaelrWCfjTiF3BxM2YuI2ARx+HI0BsmMShtU8kCxMJRe4Bdd/2z1VaQzV9KVoVeoLNfvFNutrU52N0/A==}
+    engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2196,6 +2435,16 @@ packages:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
     hasBin: true
 
+  oxlint@1.66.0:
+    resolution: {integrity: sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
   oxlint@1.67.0:
     resolution: {integrity: sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2508,6 +2757,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript@6.0.0-dev.20260416:
+    resolution: {integrity: sha512-64CCow5rQc6+oBAPqLtvZ8f3iz4WVCLwMVkg6/kOfMQlGshVOMkBhCXn+MMP4SX4Xtnz48VpD98FkptirMEuEQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2715,6 +2969,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@corsa-bind/napi-darwin-arm64@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-darwin-x64@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-linux-arm64-gnu@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-linux-arm64-musl@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-linux-x64-gnu@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-linux-x64-musl@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-win32-arm64-msvc@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi-win32-x64-msvc@0.43.0':
+    optional: true
+
+  '@corsa-bind/napi@0.43.0':
+    optionalDependencies:
+      '@corsa-bind/napi-darwin-arm64': 0.43.0
+      '@corsa-bind/napi-darwin-x64': 0.43.0
+      '@corsa-bind/napi-linux-arm64-gnu': 0.43.0
+      '@corsa-bind/napi-linux-arm64-musl': 0.43.0
+      '@corsa-bind/napi-linux-x64-gnu': 0.43.0
+      '@corsa-bind/napi-linux-x64-musl': 0.43.0
+      '@corsa-bind/napi-win32-arm64-msvc': 0.43.0
+      '@corsa-bind/napi-win32-x64-msvc': 0.43.0
 
   '@docsearch/css@4.6.3': {}
 
@@ -3024,10 +3313,16 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@0.23.0':
     optional: true
 
+  '@oxlint/binding-android-arm-eabi@1.66.0':
+    optional: true
+
   '@oxlint/binding-android-arm-eabi@1.67.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.68.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.66.0':
     optional: true
 
   '@oxlint/binding-android-arm64@1.67.0':
@@ -3036,10 +3331,16 @@ snapshots:
   '@oxlint/binding-android-arm64@1.68.0':
     optional: true
 
+  '@oxlint/binding-darwin-arm64@1.66.0':
+    optional: true
+
   '@oxlint/binding-darwin-arm64@1.67.0':
     optional: true
 
   '@oxlint/binding-darwin-arm64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.66.0':
     optional: true
 
   '@oxlint/binding-darwin-x64@1.67.0':
@@ -3048,10 +3349,16 @@ snapshots:
   '@oxlint/binding-darwin-x64@1.68.0':
     optional: true
 
+  '@oxlint/binding-freebsd-x64@1.66.0':
+    optional: true
+
   '@oxlint/binding-freebsd-x64@1.67.0':
     optional: true
 
   '@oxlint/binding-freebsd-x64@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-arm-gnueabihf@1.67.0':
@@ -3060,10 +3367,16 @@ snapshots:
   '@oxlint/binding-linux-arm-gnueabihf@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-arm-musleabihf@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-arm-musleabihf@1.67.0':
     optional: true
 
   '@oxlint/binding-linux-arm-musleabihf@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-gnu@1.67.0':
@@ -3072,10 +3385,16 @@ snapshots:
   '@oxlint/binding-linux-arm64-gnu@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-arm64-musl@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-arm64-musl@1.67.0':
     optional: true
 
   '@oxlint/binding-linux-arm64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-ppc64-gnu@1.67.0':
@@ -3084,10 +3403,16 @@ snapshots:
   '@oxlint/binding-linux-ppc64-gnu@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-riscv64-gnu@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-riscv64-gnu@1.67.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-riscv64-musl@1.67.0':
@@ -3096,10 +3421,16 @@ snapshots:
   '@oxlint/binding-linux-riscv64-musl@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-s390x-gnu@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-s390x-gnu@1.67.0':
     optional: true
 
   '@oxlint/binding-linux-s390x-gnu@1.68.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.66.0':
     optional: true
 
   '@oxlint/binding-linux-x64-gnu@1.67.0':
@@ -3108,10 +3439,16 @@ snapshots:
   '@oxlint/binding-linux-x64-gnu@1.68.0':
     optional: true
 
+  '@oxlint/binding-linux-x64-musl@1.66.0':
+    optional: true
+
   '@oxlint/binding-linux-x64-musl@1.67.0':
     optional: true
 
   '@oxlint/binding-linux-x64-musl@1.68.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.66.0':
     optional: true
 
   '@oxlint/binding-openharmony-arm64@1.67.0':
@@ -3120,16 +3457,25 @@ snapshots:
   '@oxlint/binding-openharmony-arm64@1.68.0':
     optional: true
 
+  '@oxlint/binding-win32-arm64-msvc@1.66.0':
+    optional: true
+
   '@oxlint/binding-win32-arm64-msvc@1.67.0':
     optional: true
 
   '@oxlint/binding-win32-arm64-msvc@1.68.0':
     optional: true
 
+  '@oxlint/binding-win32-ia32-msvc@1.66.0':
+    optional: true
+
   '@oxlint/binding-win32-ia32-msvc@1.67.0':
     optional: true
 
   '@oxlint/binding-win32-ia32-msvc@1.68.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.66.0':
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.67.0':
@@ -3139,6 +3485,8 @@ snapshots:
     optional: true
 
   '@oxlint/plugins@1.61.0': {}
+
+  '@oxlint/plugins@1.66.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -3408,10 +3756,26 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      eslint: 10.4.1(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.0-dev.20260416)
+      typescript: 6.0.0-dev.20260416
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
@@ -3421,6 +3785,18 @@ snapshots:
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.6.1)
+      typescript: 6.0.0-dev.20260416
     transitivePeerDependencies:
       - supports-color
 
@@ -3436,6 +3812,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.60.1(typescript@6.0.0-dev.20260416)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/types': 8.60.1
+      debug: 4.4.3
+      typescript: 6.0.0-dev.20260416
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
@@ -3445,17 +3830,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
+  '@typescript-eslint/rule-tester@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
     dependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
       ajv: 6.15.0
       eslint: 10.4.1(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.8.2
-      typescript: 6.0.3
+      typescript: 6.0.0-dev.20260416
     transitivePeerDependencies:
       - supports-color
 
@@ -3464,9 +3849,25 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/visitor-keys': 8.60.1
 
+  '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.0-dev.20260416)':
+    dependencies:
+      typescript: 6.0.0-dev.20260416
+
   '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@6.0.0-dev.20260416)
+      typescript: 6.0.0-dev.20260416
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
@@ -3482,6 +3883,21 @@ snapshots:
 
   '@typescript-eslint/types@8.60.1': {}
 
+  '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.0-dev.20260416)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.2
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.0-dev.20260416)
+      typescript: 6.0.0-dev.20260416
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.60.1(typescript@6.0.3)
@@ -3494,6 +3910,17 @@ snapshots:
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
+      eslint: 10.4.1(jiti@2.6.1)
+      typescript: 6.0.0-dev.20260416
     transitivePeerDependencies:
       - supports-color
 
@@ -3513,6 +3940,37 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260608.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260608.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260608.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260608.1
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-vue@6.0.7(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1))(vue@3.5.35(typescript@6.0.3))':
@@ -3520,6 +3978,19 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)'
       vue: 3.5.35(typescript@6.0.3)
+
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)':
+    dependencies:
+      '@oxc-project/runtime': 0.133.0
+      '@oxc-project/types': 0.133.0
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optionalDependencies:
+      '@types/node': 24.10.15
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      typescript: 6.0.0-dev.20260416
+      yaml: 2.8.1
 
   '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.1)':
     dependencies:
@@ -3551,6 +4022,46 @@ snapshots:
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
+
+  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)
+      es-module-lexer: 1.7.0
+      obug: 2.1.2
+      pixelmatch: 7.2.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      vite: 7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1)
+      ws: 8.21.0
+    optionalDependencies:
+      '@types/node': 24.10.15
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - yaml
 
   '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)':
     dependencies:
@@ -3591,6 +4102,7 @@ snapshots:
       - unrun
       - utf-8-validate
       - yaml
+    optional: true
 
   '@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.24':
     optional: true
@@ -3781,6 +4293,14 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   constructs@10.6.0: {}
+
+  corsa-oxlint@0.43.0(oxlint-tsgolint@0.23.0):
+    dependencies:
+      '@corsa-bind/napi': 0.43.0
+      '@oxlint/plugins': 1.66.0
+      oxlint: 1.66.0(oxlint-tsgolint@0.23.0)
+    transitivePeerDependencies:
+      - oxlint-tsgolint
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4433,6 +4953,31 @@ snapshots:
       '@oxc-minify/binding-win32-ia32-msvc': 0.134.0
       '@oxc-minify/binding-win32-x64-msvc': 0.134.0
 
+  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.52.0
+      '@oxfmt/binding-android-arm64': 0.52.0
+      '@oxfmt/binding-darwin-arm64': 0.52.0
+      '@oxfmt/binding-darwin-x64': 0.52.0
+      '@oxfmt/binding-freebsd-x64': 0.52.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
+      '@oxfmt/binding-linux-arm64-musl': 0.52.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-musl': 0.52.0
+      '@oxfmt/binding-openharmony-arm64': 0.52.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
+      '@oxfmt/binding-win32-x64-msvc': 0.52.0
+      vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+
   oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
     dependencies:
       tinypool: 2.1.0
@@ -4457,6 +5002,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
       vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+    optional: true
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -4466,6 +5012,53 @@ snapshots:
       '@oxlint-tsgolint/linux-x64': 0.23.0
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
+
+  oxlint@1.66.0(oxlint-tsgolint@0.23.0):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.66.0
+      '@oxlint/binding-android-arm64': 1.66.0
+      '@oxlint/binding-darwin-arm64': 1.66.0
+      '@oxlint/binding-darwin-x64': 1.66.0
+      '@oxlint/binding-freebsd-x64': 1.66.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.66.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.66.0
+      '@oxlint/binding-linux-arm64-gnu': 1.66.0
+      '@oxlint/binding-linux-arm64-musl': 1.66.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.66.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.66.0
+      '@oxlint/binding-linux-riscv64-musl': 1.66.0
+      '@oxlint/binding-linux-s390x-gnu': 1.66.0
+      '@oxlint/binding-linux-x64-gnu': 1.66.0
+      '@oxlint/binding-linux-x64-musl': 1.66.0
+      '@oxlint/binding-openharmony-arm64': 1.66.0
+      '@oxlint/binding-win32-arm64-msvc': 1.66.0
+      '@oxlint/binding-win32-ia32-msvc': 1.66.0
+      '@oxlint/binding-win32-x64-msvc': 1.66.0
+      oxlint-tsgolint: 0.23.0
+
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.67.0
+      '@oxlint/binding-android-arm64': 1.67.0
+      '@oxlint/binding-darwin-arm64': 1.67.0
+      '@oxlint/binding-darwin-x64': 1.67.0
+      '@oxlint/binding-freebsd-x64': 1.67.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
+      '@oxlint/binding-linux-arm64-gnu': 1.67.0
+      '@oxlint/binding-linux-arm64-musl': 1.67.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-musl': 1.67.0
+      '@oxlint/binding-linux-s390x-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-musl': 1.67.0
+      '@oxlint/binding-openharmony-arm64': 1.67.0
+      '@oxlint/binding-win32-arm64-msvc': 1.67.0
+      '@oxlint/binding-win32-ia32-msvc': 1.67.0
+      '@oxlint/binding-win32-x64-msvc': 1.67.0
+      oxlint-tsgolint: 0.23.0
+      vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
 
   oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
     optionalDependencies:
@@ -4490,6 +5083,7 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+    optional: true
 
   oxlint@1.68.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)):
     optionalDependencies:
@@ -4813,6 +5407,10 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-api-utils@2.5.0(typescript@6.0.0-dev.20260416):
+    dependencies:
+      typescript: 6.0.0-dev.20260416
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -4830,9 +5428,20 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.0-dev.20260416)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416)
+      eslint: 10.4.1(jiti@2.6.1)
+      typescript: 6.0.0-dev.20260416
+    transitivePeerDependencies:
+      - supports-color
+
   typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.0-dev.20260416))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
@@ -4840,6 +5449,8 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  typescript@6.0.0-dev.20260416: {}
 
   typescript@6.0.3: {}
 
@@ -4909,6 +5520,56 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1):
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@oxlint/plugins': 1.61.0
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(yaml@2.8.1)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)
+      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.0-dev.20260416)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
+      oxlint-tsgolint: 0.23.0
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.24
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.24
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.24
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.24
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.24
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.24
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.24
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - svelte
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - vite
+      - yaml
+
   vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -4958,6 +5619,7 @@ snapshots:
       - utf-8-validate
       - vite
       - yaml
+    optional: true
 
   vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ packages:
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@^0.1.11
   vitest: npm:@voidzero-dev/vite-plus-test@^0.1.11
+  oxlint-tsgolint: 0.22.0
+  oxlint: 1.66.0
 engineStrict: true
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@^0.1.11
 engineStrict: true
 minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - corsa-oxlint
+  - "@corsa-bind/*"
 onlyBuiltDependencies:
   - esbuild
 useNodeVersion: 24.14.1

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -36,6 +36,6 @@ check_oxlint_output() {
   echo "SUCCESS: Expected error count found!"
 }
 
-check_eslint_output "vp run -F @eslint-plugin-awscdk/example-eslint eslint:esm"
-check_eslint_output "vp run -F @eslint-plugin-awscdk/example-eslint eslint:cjs"
-check_oxlint_output "vp run -F @eslint-plugin-awscdk/example-eslint oxlint"
+check_eslint_output "vp run -F @eslint-plugin-awscdk/example eslint:esm"
+check_eslint_output "vp run -F @eslint-plugin-awscdk/example eslint:cjs"
+check_oxlint_output "vp run -F @eslint-plugin-awscdk/example oxlint"

--- a/src/__tests__/construct-constructor-property.test.ts
+++ b/src/__tests__/construct-constructor-property.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
-
+import { RuleTester } from "corsa-oxlint";
 import { constructConstructorProperty } from "../rules/construct-constructor-property";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("construct-constructor-property", constructConstructorProperty, {
   valid: [

--- a/src/__tests__/construct-constructor-property.test.ts
+++ b/src/__tests__/construct-constructor-property.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "corsa-oxlint";
+
 import { constructConstructorProperty } from "../rules/construct-constructor-property";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
-
+import { RuleTester } from "corsa-oxlint";
 import { noConstructInInterface } from "../rules/no-construct-in-interface";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-construct-in-interface", noConstructInInterface, {
   valid: [

--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "corsa-oxlint";
+
 import { noConstructInInterface } from "../rules/no-construct-in-interface";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/no-construct-in-interface.test.ts
+++ b/src/__tests__/no-construct-in-interface.test.ts
@@ -92,8 +92,8 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       code: `
       class Resource {}
 
-      declare module baseService {
-        interface IService {
+      namespace baseService {
+        export interface IService {
           serviceArn: string;
         }
         export abstract class BaseService extends Resource implements IService {
@@ -104,7 +104,7 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
         }
       }
 
-      declare module ecs {
+      namespace ecs {
         export interface IFargateService extends baseService.IService {}
         export class FargateService extends baseService.BaseService implements IFargateService {
           readonly serviceArn: string;
@@ -222,7 +222,7 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       interface IService {
         serviceArn: string;
       }
-      declare module ecs {
+      namespace ecs {
         export interface IFargateService extends IService {}
       }
       export abstract class BaseService extends Resource implements IService {
@@ -258,7 +258,7 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
         }
       }
 
-      declare module ecs {
+      namespace ecs {
         export class FargateService extends BaseService implements IFargateService {
           readonly serviceArn: string;
           constructor() {

--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -236,7 +236,7 @@ ruleTester.run(
           interface IService {
             serviceArn: string;
           }
-          declare module ecs {
+          namespace ecs {
             export interface IFargateService extends IService {}
           }
           export abstract class BaseService extends Resource implements IService {

--- a/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
+import { RuleTester } from "corsa-oxlint";
 
 import { noConstructInPublicPropertyOfConstruct } from "../rules/no-construct-in-public-property-of-construct";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run(
   "no-construct-in-public-property-of-construct",

--- a/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/src/__tests__/no-construct-stack-suffix.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
+import { RuleTester } from "corsa-oxlint";
 
 import { noConstructStackSuffix } from "../rules/no-construct-stack-suffix";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
   valid: [

--- a/src/__tests__/no-mutable-property-of-props-interface.test.ts
+++ b/src/__tests__/no-mutable-property-of-props-interface.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
+import { RuleTester } from "corsa-oxlint";
 
 import { noMutablePropertyOfPropsInterface } from "../rules/no-mutable-property-of-props-interface";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfPropsInterface, {
   valid: [

--- a/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
+import { RuleTester } from "corsa-oxlint";
 
 import { noMutablePublicPropertyOfConstruct } from "../rules/no-mutable-public-property-of-construct";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropertyOfConstruct, {
   valid: [

--- a/src/__tests__/no-parent-name-construct-id-match.test.ts
+++ b/src/__tests__/no-parent-name-construct-id-match.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { noParentNameConstructIdMatch } from "../rules/no-parent-name-construct-id-match";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/no-parent-name-construct-id-match.test.ts
+++ b/src/__tests__/no-parent-name-construct-id-match.test.ts
@@ -61,9 +61,7 @@ ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch
       code: `
       class Construct {}
       class SampleClass {
-        constructor(scope: Construct, id: string) {
-          super(scope, id);
-        }
+        constructor(scope: Construct, id: string) {}
       }
       class TestConstruct extends Construct {
         constructor(scope: Construct, id: string) {
@@ -83,7 +81,6 @@ ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch
       }
       class SampleConstruct {
         constructor(scope: Construct, id: string) {
-          super(scope, id);
           new SampleClass(scope, "TestConstruct");
         }
       }`,

--- a/src/__tests__/no-parent-name-construct-id-match.test.ts
+++ b/src/__tests__/no-parent-name-construct-id-match.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { noParentNameConstructIdMatch } from "../rules/no-parent-name-construct-id-match";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch, {
   valid: [

--- a/src/__tests__/no-unused-props.test.ts
+++ b/src/__tests__/no-unused-props.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { noUnusedProps } from "../rules/no-unused-props";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/no-unused-props.test.ts
+++ b/src/__tests__/no-unused-props.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { noUnusedProps } from "../rules/no-unused-props";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-unused-props", noUnusedProps, {
   valid: [

--- a/src/__tests__/no-variable-construct-id.test.ts
+++ b/src/__tests__/no-variable-construct-id.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { noVariableConstructId } from "../rules/no-variable-construct-id";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("no-variable-construct-id", noVariableConstructId, {
   valid: [

--- a/src/__tests__/no-variable-construct-id.test.ts
+++ b/src/__tests__/no-variable-construct-id.test.ts
@@ -209,9 +209,7 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       code: `
       class Construct {}
       class TargetConstruct {
-        constructor(scope: Construct, id: string) {
-          super(scope, id);
-        }
+        constructor(scope: Construct, id: string) {}
       }
       class SampleConstruct extends Construct {
         constructor(scope: Construct, id: string) {

--- a/src/__tests__/no-variable-construct-id.test.ts
+++ b/src/__tests__/no-variable-construct-id.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { noVariableConstructId } from "../rules/no-variable-construct-id";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/pascal-case-construct-id.test.ts
+++ b/src/__tests__/pascal-case-construct-id.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { pascalCaseConstructId } from "../rules/pascal-case-construct-id";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
   valid: [

--- a/src/__tests__/pascal-case-construct-id.test.ts
+++ b/src/__tests__/pascal-case-construct-id.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { pascalCaseConstructId } from "../rules/pascal-case-construct-id";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/prefer-grants-property.test.ts
+++ b/src/__tests__/prefer-grants-property.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { preferGrantsProperty } from "../rules/prefer-grants-property";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("prefer-grants-property", preferGrantsProperty, {
   valid: [

--- a/src/__tests__/prefer-grants-property.test.ts
+++ b/src/__tests__/prefer-grants-property.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { preferGrantsProperty } from "../rules/prefer-grants-property";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/src/__tests__/prevent-construct-id-collision.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { preventConstructIdCollision } from "../rules/prevent-construct-id-collision";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/src/__tests__/prevent-construct-id-collision.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { preventConstructIdCollision } from "../rules/prevent-construct-id-collision";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
   valid: [

--- a/src/__tests__/props-name-convention.test.ts
+++ b/src/__tests__/props-name-convention.test.ts
@@ -1,16 +1,9 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+
+import { RuleTester } from "corsa-oxlint";
 import { propsNameConvention } from "../rules/props-name-convention";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("props-name-convention", propsNameConvention, {
   valid: [

--- a/src/__tests__/props-name-convention.test.ts
+++ b/src/__tests__/props-name-convention.test.ts
@@ -1,6 +1,5 @@
-
-
 import { RuleTester } from "corsa-oxlint";
+
 import { propsNameConvention } from "../rules/props-name-convention";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/require-jsdoc.test.ts
+++ b/src/__tests__/require-jsdoc.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { requireJSDoc } from "../rules/require-jsdoc";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("require-jsdoc", requireJSDoc, {
   valid: [

--- a/src/__tests__/require-jsdoc.test.ts
+++ b/src/__tests__/require-jsdoc.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { requireJSDoc } from "../rules/require-jsdoc";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/require-passing-this.test.ts
+++ b/src/__tests__/require-passing-this.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { requirePassingThis } from "../rules/require-passing-this";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/require-passing-this.test.ts
+++ b/src/__tests__/require-passing-this.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { requirePassingThis } from "../rules/require-passing-this";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("require-passing-this", requirePassingThis, {
   valid: [

--- a/src/__tests__/require-passing-this.test.ts
+++ b/src/__tests__/require-passing-this.test.ts
@@ -28,9 +28,7 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       code: `
       class Construct {}
       class SampleConstruct {
-        constructor(scope: Construct, id: string) {
-          super(scope, id);
-        }
+        constructor(scope: Construct, id: string) {}
       }
       class TestConstruct extends Construct {
         constructor(scope: Construct, id: string) {

--- a/src/__tests__/require-props-default-doc.test.ts
+++ b/src/__tests__/require-props-default-doc.test.ts
@@ -1,5 +1,5 @@
-
 import { RuleTester } from "corsa-oxlint";
+
 import { requirePropsDefaultDoc } from "../rules/require-props-default-doc";
 
 const ruleTester = new RuleTester();

--- a/src/__tests__/require-props-default-doc.test.ts
+++ b/src/__tests__/require-props-default-doc.test.ts
@@ -1,16 +1,8 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 
+import { RuleTester } from "corsa-oxlint";
 import { requirePropsDefaultDoc } from "../rules/require-props-default-doc";
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ["*.ts*"],
-      },
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run("require-default-doc-optional-props", requirePropsDefaultDoc, {
   valid: [

--- a/src/configs/eslint/classic-config.ts
+++ b/src/configs/eslint/classic-config.ts
@@ -1,11 +1,11 @@
-import { ClassicConfig } from "@typescript-eslint/utils/ts-eslint";
+import type { Linter } from "eslint";
 
 type EslintClassicConfig = {
   plugins: ["awscdk"];
-  rules: ClassicConfig.RulesRecord;
+  rules: Linter.RulesRecord;
 };
 
-const createClassicConfig = (rules: ClassicConfig.RulesRecord): EslintClassicConfig => {
+const createClassicConfig = (rules: Linter.RulesRecord): EslintClassicConfig => {
   return {
     plugins: ["awscdk"],
     rules,

--- a/src/configs/eslint/classic-config.ts
+++ b/src/configs/eslint/classic-config.ts
@@ -1,18 +1,18 @@
 import { ClassicConfig } from "@typescript-eslint/utils/ts-eslint";
 
-type ClassicRulesConfig = {
+type EslintClassicConfig = {
   plugins: ["awscdk"];
   rules: ClassicConfig.RulesRecord;
 };
 
-const createClassicConfig = (rules: ClassicConfig.RulesRecord): ClassicRulesConfig => {
+const createClassicConfig = (rules: ClassicConfig.RulesRecord): EslintClassicConfig => {
   return {
     plugins: ["awscdk"],
     rules,
   };
 };
 
-export const recommended: ClassicRulesConfig = createClassicConfig({
+export const recommended: EslintClassicConfig = createClassicConfig({
   "awscdk/construct-constructor-property": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",
@@ -27,7 +27,7 @@ export const recommended: ClassicRulesConfig = createClassicConfig({
   "awscdk/require-passing-this": ["error", { allowNonThisAndDisallowScope: true }],
 });
 
-export const strict: ClassicRulesConfig = createClassicConfig({
+export const strict: EslintClassicConfig = createClassicConfig({
   "awscdk/construct-constructor-property": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",

--- a/src/configs/eslint/flat-config.ts
+++ b/src/configs/eslint/flat-config.ts
@@ -1,8 +1,8 @@
 import tsParser from "@typescript-eslint/parser";
+import { Linter } from "eslint";
 
 import { name, version } from "../../../package.json";
 import { rules } from "../../rules";
-import { Linter } from "eslint";
 
 export type EslintFlatConfig = Record<string, unknown> & {
   plugins?: Record<string, Record<string, unknown>>;

--- a/src/configs/eslint/flat-config.ts
+++ b/src/configs/eslint/flat-config.ts
@@ -1,13 +1,13 @@
 import tsParser from "@typescript-eslint/parser";
-import { FlatConfig as _FlatConfig } from "@typescript-eslint/utils/ts-eslint";
+import { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
-import { name, version } from "../../package.json";
-import { rules } from "../rules";
+import { name, version } from "../../../package.json";
+import { rules } from "../../rules";
 
-export type FlatConfig = Record<string, unknown> & {
+export type EslintFlatConfig = Record<string, unknown> & {
   plugins?: Record<string, Record<string, unknown>>;
   languageOptions?: Record<string, unknown>;
-  rules?: _FlatConfig.Rules;
+  rules?: FlatConfig.Rules;
 };
 
 const awscdk = {
@@ -15,7 +15,7 @@ const awscdk = {
   rules,
 };
 
-const createFlatConfig = (rules: _FlatConfig.Rules): FlatConfig => {
+const createFlatConfig = (rules: FlatConfig.Rules): EslintFlatConfig => {
   return {
     plugins: {
       awscdk,
@@ -30,7 +30,7 @@ const createFlatConfig = (rules: _FlatConfig.Rules): FlatConfig => {
   };
 };
 
-export const recommended: FlatConfig = createFlatConfig({
+export const recommended: EslintFlatConfig = createFlatConfig({
   "awscdk/construct-constructor-property": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",
@@ -45,7 +45,7 @@ export const recommended: FlatConfig = createFlatConfig({
   "awscdk/require-passing-this": ["error", { allowNonThisAndDisallowScope: true }],
 });
 
-export const strict: FlatConfig = createFlatConfig({
+export const strict: EslintFlatConfig = createFlatConfig({
   "awscdk/construct-constructor-property": "error",
   "awscdk/no-construct-in-interface": "error",
   "awscdk/no-construct-in-public-property-of-construct": "error",

--- a/src/configs/eslint/flat-config.ts
+++ b/src/configs/eslint/flat-config.ts
@@ -1,13 +1,13 @@
 import tsParser from "@typescript-eslint/parser";
-import { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
 
 import { name, version } from "../../../package.json";
 import { rules } from "../../rules";
+import { Linter } from "eslint";
 
 export type EslintFlatConfig = Record<string, unknown> & {
   plugins?: Record<string, Record<string, unknown>>;
   languageOptions?: Record<string, unknown>;
-  rules?: FlatConfig.Rules;
+  rules?: Linter.RulesRecord;
 };
 
 const awscdk = {
@@ -15,7 +15,7 @@ const awscdk = {
   rules,
 };
 
-const createFlatConfig = (rules: FlatConfig.Rules): EslintFlatConfig => {
+const createFlatConfig = (rules: Linter.RulesRecord): EslintFlatConfig => {
   return {
     plugins: {
       awscdk,

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,5 +1,8 @@
-import { recommended as classicRecommended, strict as classicStrict } from "./classic-config";
-import { recommended, strict } from "./flat-config";
+import {
+  recommended as classicRecommended,
+  strict as classicStrict,
+} from "./eslint/classic-config";
+import { recommended, strict } from "./eslint/flat-config";
 
 export const configs: Readonly<{
   recommended: typeof recommended;

--- a/src/core/ast-node/finder/child-nodes.ts
+++ b/src/core/ast-node/finder/child-nodes.ts
@@ -1,10 +1,10 @@
-import { TSESTree } from "@typescript-eslint/utils";
+import { ESTree } from "corsa-oxlint";
 
 /**
- * find child nodes from a TSESTree.Node
+ * find child nodes from a ESTree.Node
  */
-export const findChildNodes = (node: TSESTree.Node): TSESTree.Node[] => {
-  return Object.entries(node).reduce<TSESTree.Node[]>((acc, [key, value]) => {
+export const findChildNodes = (node: ESTree.Node): ESTree.Node[] => {
+  return Object.entries(node).reduce<ESTree.Node[]>((acc, [key, value]) => {
     if (["parent", "range", "loc"].includes(key)) return acc; // Keys to skip to avoid circular references and unnecessary properties
     if (isESTreeNode(value)) return [...acc, value];
     if (Array.isArray(value)) return [...acc, ...value.filter(isESTreeNode)];
@@ -13,9 +13,9 @@ export const findChildNodes = (node: TSESTree.Node): TSESTree.Node[] => {
 };
 
 /**
- * Type guard to check if a value is a TSESTree.Node
+ * Type guard to check if a value is a ESTree.Node
  */
-const isESTreeNode = (value: unknown): value is TSESTree.Node => {
+const isESTreeNode = (value: unknown): value is ESTree.Node => {
   return (
     value !== null &&
     typeof value === "object" &&

--- a/src/core/ast-node/finder/constructor.ts
+++ b/src/core/ast-node/finder/constructor.ts
@@ -10,7 +10,6 @@ export const findConstructor = (
 ): ESTree.MethodDefinition | undefined => {
   return node.body.body.find(
     (member): member is ESTree.MethodDefinition =>
-      member.type === AST_NODE_TYPES.MethodDefinition &&
-      member.kind === "constructor",
+      member.type === AST_NODE_TYPES.MethodDefinition && member.kind === "constructor",
   );
 };

--- a/src/core/ast-node/finder/constructor.ts
+++ b/src/core/ast-node/finder/constructor.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 /**
  * Finds the constructor method in a class declaration
@@ -6,10 +6,11 @@ import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
  * @returns The constructor method definition or undefined if not found
  */
 export const findConstructor = (
-  node: TSESTree.ClassDeclaration,
-): TSESTree.MethodDefinition | undefined => {
+  node: ESTree.ClassDeclaration | ESTree.ClassExpression,
+): ESTree.MethodDefinition | undefined => {
   return node.body.body.find(
-    (member): member is TSESTree.MethodDefinition =>
-      member.type === AST_NODE_TYPES.MethodDefinition && member.kind === "constructor",
+    (member): member is ESTree.MethodDefinition =>
+      member.type === AST_NODE_TYPES.MethodDefinition &&
+      member.kind === "constructor",
   );
 };

--- a/src/core/ast-node/finder/enclosing-class.ts
+++ b/src/core/ast-node/finder/enclosing-class.ts
@@ -9,6 +9,7 @@ import { ESTree } from "corsa-oxlint";
 export const findEnclosingClass = (node: ESTree.Node): ESTree.ClassDeclaration | undefined => {
   if (!node.parent) return undefined;
   if (node.parent.type === AST_NODE_TYPES.ClassDeclaration) {
+    // FIXME: not use `as` assertion
     return node.parent as ESTree.ClassDeclaration;
   }
   return findEnclosingClass(node.parent);

--- a/src/core/ast-node/finder/enclosing-class.ts
+++ b/src/core/ast-node/finder/enclosing-class.ts
@@ -1,12 +1,15 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { ESTree } from "corsa-oxlint";
 
 /**
  * Find the enclosing ClassDeclaration from a given node
  * @param node The node to start searching from
  * @returns The enclosing ClassDeclaration or undefined if not found
  */
-export const findEnclosingClass = (node: TSESTree.Node): TSESTree.ClassDeclaration | undefined => {
+export const findEnclosingClass = (node: ESTree.Node): ESTree.ClassDeclaration | undefined => {
   if (!node.parent) return undefined;
-  if (node.parent.type === AST_NODE_TYPES.ClassDeclaration) return node.parent;
+  if (node.parent.type === AST_NODE_TYPES.ClassDeclaration) {
+    return node.parent as ESTree.ClassDeclaration;
+  }
   return findEnclosingClass(node.parent);
 };

--- a/src/core/ast-node/finder/enclosing-class.ts
+++ b/src/core/ast-node/finder/enclosing-class.ts
@@ -1,5 +1,4 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
-import { ESTree } from "corsa-oxlint";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 /**
  * Find the enclosing ClassDeclaration from a given node

--- a/src/core/ast-node/finder/property-name.ts
+++ b/src/core/ast-node/finder/property-name.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 /**
  * Retrieves the property names from an array of properties.
@@ -7,7 +7,7 @@ import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
  * @returns An array of property names.
  */
 export const findPropertyNames = (
-  properties: (TSESTree.Property | TSESTree.RestElement)[],
+  properties: (ESTree.Property | ESTree.RestElement)[],
 ): string[] => {
   return properties.reduce<string[]>(
     (acc, prop) =>

--- a/src/core/ast-node/finder/public-property.ts
+++ b/src/core/ast-node/finder/public-property.ts
@@ -42,6 +42,7 @@ const findPublicProperty = (property: ESTree.Node): PublicProperty | undefined =
       if (!property.parameter.typeAnnotation) return;
       return {
         name: property.parameter.name,
+        // FIXME: not use `as` assertion
         node: property as ESTree.TSParameterProperty,
       };
     }
@@ -52,6 +53,7 @@ const findPublicProperty = (property: ESTree.Node): PublicProperty | undefined =
       if (!property.typeAnnotation) return;
       return {
         name: property.key.name,
+        // FIXME: not use `as` assertion
         node: property as ESTree.PropertyDefinition,
       };
     }

--- a/src/core/ast-node/finder/public-property.ts
+++ b/src/core/ast-node/finder/public-property.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { findConstructor } from "./constructor";
 
@@ -10,58 +10,49 @@ export type PublicProperty = {
   /**
    * AST node representing the public property
    */
-  node:
-    | TSESTree.PropertyDefinitionComputedName
-    | TSESTree.PropertyDefinitionNonComputedName
-    | TSESTree.TSParameterProperty;
+  node: ESTree.TSParameterProperty | ESTree.PropertyDefinition;
 };
 
-export const findPublicPropertiesInClass = (node: TSESTree.ClassDeclaration): PublicProperty[] => {
+export const findPublicPropertiesInClass = (
+  node: ESTree.ClassDeclaration | ESTree.ClassExpression,
+): PublicProperty[] => {
   const constructorProperties = findPropertiesInConstructor(node);
   const classElementProperties = findPropertiesInClassElement(node);
   return [...constructorProperties, ...classElementProperties];
 };
 
-const findPropertiesInConstructor = (node: TSESTree.ClassDeclaration) => {
+const findPropertiesInConstructor = (node: ESTree.ClassDeclaration | ESTree.ClassExpression) => {
   const constructor = findConstructor(node);
   if (!constructor) return [];
   return constructor.value.params.flatMap((property) => findPublicProperty(property) ?? []);
 };
 
-const findPropertiesInClassElement = (node: TSESTree.ClassDeclaration): PublicProperty[] => {
+const findPropertiesInClassElement = (
+  node: ESTree.ClassDeclaration | ESTree.ClassExpression,
+): PublicProperty[] => {
   return node.body.body.flatMap((property) => findPublicProperty(property) ?? []);
 };
 
-const findPublicProperty = (
-  property: TSESTree.Parameter | TSESTree.ClassElement,
-): PublicProperty | undefined => {
+const findPublicProperty = (property: ESTree.Node): PublicProperty | undefined => {
   switch (property.type) {
     // NOTE: get from constructor
     case AST_NODE_TYPES.TSParameterProperty: {
-      if (property.parameter.type !== AST_NODE_TYPES.Identifier) {
-        return;
-      }
-      if (["private", "protected"].includes(property.accessibility ?? "")) {
-        return;
-      }
+      if (property.parameter.type !== AST_NODE_TYPES.Identifier) return;
+      if (["private", "protected"].includes(property.accessibility ?? "")) return;
       if (!property.parameter.typeAnnotation) return;
       return {
         name: property.parameter.name,
-        node: property,
+        node: property as ESTree.TSParameterProperty,
       };
     }
     // NOTE: get from class element
     case AST_NODE_TYPES.PropertyDefinition: {
-      if (property.key.type !== AST_NODE_TYPES.Identifier) {
-        return;
-      }
-      if (["private", "protected"].includes(property.accessibility ?? "")) {
-        return;
-      }
+      if (property.key.type !== AST_NODE_TYPES.Identifier) return;
+      if (["private", "protected"].includes(property.accessibility ?? "")) return;
       if (!property.typeAnnotation) return;
       return {
         name: property.key.name,
-        node: property,
+        node: property as ESTree.PropertyDefinition,
       };
     }
   }

--- a/src/core/cdk-construct/type-checker/is-construct-or-stack.ts
+++ b/src/core/cdk-construct/type-checker/is-construct-or-stack.ts
@@ -1,4 +1,4 @@
-import { Type } from "typescript";
+import { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
 import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
 
@@ -9,9 +9,14 @@ import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-
  * @returns True if the type extends Construct or Stack, otherwise false
  */
 export const isConstructOrStackType = (
-  type: Type,
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
   ignoredClasses: readonly string[] = ["App", "Stage", "CfnOutput"] as const,
 ): boolean => {
-  if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
-  return isExtendsFromTargetSuperClass(type, ["Construct", "Stack"], isConstructOrStackType);
+  return isExtendsFromTargetSuperClass({
+    type,
+    checker,
+    targetSuperClasses: ["Construct", "Stack"],
+    ignoredClasses,
+  });
 };

--- a/src/core/cdk-construct/type-checker/is-construct.ts
+++ b/src/core/cdk-construct/type-checker/is-construct.ts
@@ -1,17 +1,23 @@
-import { Type } from "typescript";
+import { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
 import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
 
 /**
  * Check if the type extends Construct
  * @param type - The type to check
+ * @param checker - The type checker
  * @param ignoredClasses - Classes that inherit from Construct Class but do not want to be treated as Construct Class
  * @returns True if the type extends Construct, otherwise false
  */
 export const isConstructType = (
-  type: Type,
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
   ignoredClasses: readonly string[] = ["App", "Stage", "CfnOutput", "Stack"] as const,
 ): boolean => {
-  if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
-  return isExtendsFromTargetSuperClass(type, ["Construct"], isConstructType);
+  return isExtendsFromTargetSuperClass({
+    type,
+    checker,
+    targetSuperClasses: ["Construct"],
+    ignoredClasses,
+  });
 };

--- a/src/core/cdk-construct/type-checker/is-resource-with-readonly-interface.ts
+++ b/src/core/cdk-construct/type-checker/is-resource-with-readonly-interface.ts
@@ -1,12 +1,5 @@
-import {
-  isClassDeclaration,
-  isIdentifier,
-  isPropertyAccessExpression,
-  SyntaxKind,
-  Type,
-} from "typescript";
+import { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
-import { isClassType } from "../../ts-type/checker/is-class";
 import { isResourceType } from "./is-resource";
 
 /**
@@ -33,33 +26,40 @@ import { isResourceType } from "./is-resource";
  * class CustomResource extends Resource { ... } // No matching interface
  * class EdgeFunction extends Resource implements IVersion { ... } // Interface doesn't match naming pattern
  */
-export const isResourceWithReadonlyInterface = (type: Type): boolean => {
-  if (!isResourceType(type) || !type.symbol?.name) return false;
-  if (isIgnoreClass(type.symbol.name)) return false;
-  return hasMatchingInterfaceInHierarchy(type);
+export const isResourceWithReadonlyInterface = (
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
+): boolean => {
+  if (!type || !isResourceType(type, checker)) return false;
+  const className = checker.getSymbolOfType(type)?.name;
+  if (!className || isIgnoreClass(className)) return false;
+  return hasMatchingInterfaceInHierarchy(type, checker);
 };
 
 /**
  * Checks if a type or any of its base classes implements an interface matching its class name
  * @param type - The TypeScript type to check
+ * @param checker - The type checker to analyze types and their relationships
  * @returns true if any class in the hierarchy implements a matching interface
  * @private
  */
-const hasMatchingInterfaceInHierarchy = (type: Type): boolean => {
+const hasMatchingInterfaceInHierarchy = (
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): boolean => {
   const processedTypes = new Set<string>();
 
-  const checkTypeAndBases = (currentType: Type): boolean => {
-    const symbol = currentType.getSymbol?.() ?? currentType.symbol;
-    if (!symbol?.name) return false;
+  const checkTypeAndBases = (currentType: CorsaType): boolean => {
+    const currentClassName = checker.getSymbolOfType(currentType)?.name;
+    if (!currentClassName) return false;
 
     // Skip if already processed
-    if (processedTypes.has(symbol.name)) return false;
-    processedTypes.add(symbol.name);
+    if (processedTypes.has(currentClassName)) return false;
+    processedTypes.add(currentClassName);
 
-    const currentClassName = symbol.name;
     if (isIgnoreClass(currentClassName)) return false;
 
-    const directInterfaces = getDirectImplementedInterfaceNames(currentType);
+    const directInterfaces = getImplementedInterfaceNames(currentType, checker);
 
     // NOTE: Check if any interface matches this class name
     if (
@@ -70,8 +70,8 @@ const hasMatchingInterfaceInHierarchy = (type: Type): boolean => {
       return true;
     }
 
-    const baseTypes = currentType.getBaseTypes?.() ?? [];
-    return baseTypes.some((baseType) => isClassType(baseType) && checkTypeAndBases(baseType));
+    const baseTypes = checker.getBaseTypes(currentType);
+    return baseTypes.some((baseType) => checkTypeAndBases(baseType));
   };
 
   return checkTypeAndBases(type);
@@ -90,16 +90,12 @@ const hasMatchingInterfaceInHierarchy = (type: Type): boolean => {
  * @returns boolean - true if the interface name matches the class name patterns, false otherwise
  */
 const checkInterfaceMatchClassName = (interfaceName: string, classname: string) => {
-  const simpleInterfaceName = interfaceName.includes(".")
-    ? (interfaceName.split(".").pop() ?? interfaceName)
-    : interfaceName;
-
   // Pattern 1: Class name with I prefix
-  if (simpleInterfaceName === `I${classname}`) return true;
+  if (interfaceName === `I${classname}`) return true;
 
   // Pattern 2: Class name without Base suffix/prefix with I prefix
   const classNameWithoutBase = classname.replace(/^Base|Base$/g, "");
-  if (classNameWithoutBase && simpleInterfaceName === `I${classNameWithoutBase}`) {
+  if (classNameWithoutBase && interfaceName === `I${classNameWithoutBase}`) {
     return true;
   }
 
@@ -107,46 +103,20 @@ const checkInterfaceMatchClassName = (interfaceName: string, classname: string) 
   const baseVMatch = /^(.+)BaseV(\d+)$/.exec(classname);
   if (!baseVMatch) return false;
   const [, baseName, version] = baseVMatch;
-  return simpleInterfaceName === `I${baseName}V${version}`;
+  return interfaceName === `I${baseName}V${version}`;
 };
 
 /**
- * Retrieves interface names directly implemented by a type (not including inherited interfaces)
- * @param type - The TypeScript type to analyze
- * @returns Array of interface names directly implemented by this type
+ * Retrieves interface names a type implements (inherited interfaces included).
  * @private
  */
-const getDirectImplementedInterfaceNames = (type: Type): string[] => {
-  const symbol = type.getSymbol?.() ?? type.symbol;
-  if (!symbol?.name) return [];
-
-  const declarations = symbol.getDeclarations ? symbol.getDeclarations() : symbol.declarations;
-  if (!declarations?.length) return [];
-
-  return declarations.reduce<string[]>((acc, decl) => {
-    if (!isClassDeclaration(decl)) return acc;
-
-    const heritageClauses = decl.heritageClauses;
-    if (!heritageClauses) return acc;
-
-    return heritageClauses.reduce<string[]>((hcAcc, hc) => {
-      if (hc.token !== SyntaxKind.ImplementsKeyword) return hcAcc;
-
-      return hc.types.reduce<string[]>((typeAcc, type) => {
-        const expression = type.expression;
-        if (!expression) return typeAcc;
-        if (isIdentifier(expression)) return [...typeAcc, expression.text];
-        if (!isPropertyAccessExpression(expression)) return typeAcc;
-
-        const namespace = expression.expression;
-        const interfaceName = expression.name;
-        if (isIdentifier(namespace) && isIdentifier(interfaceName)) {
-          return [...typeAcc, `${namespace.text}.${interfaceName.text}`];
-        }
-
-        return typeAcc;
-      }, []);
-    }, []);
+const getImplementedInterfaceNames = (
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): string[] => {
+  return checker.getImplementedTypesOfType(type).reduce<string[]>((acc, t) => {
+    const name = checker.getSymbolOfType(t)?.name;
+    return name ? [...acc, name] : acc;
   }, []);
 };
 

--- a/src/core/cdk-construct/type-checker/is-resource.ts
+++ b/src/core/cdk-construct/type-checker/is-resource.ts
@@ -1,17 +1,23 @@
-import { Type } from "typescript";
+import { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
 import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
 
 /**
  * Check if the type extends Resource
  * @param type - The type to check
+ * @param checker - The type checker to use
  * @param ignoredClasses - Classes that inherit from Resource Class but do not want to be treated as Resource Class
  * @returns True if the type extends Resource, otherwise false
  */
 export const isResourceType = (
-  type: Type,
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
   ignoredClasses: readonly string[] = [], // App, Stage, CfnOutput, Stack are not extended Resource, so no need to ignore them
 ): boolean => {
-  if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
-  return isExtendsFromTargetSuperClass(type, ["Resource"], isResourceType);
+  return isExtendsFromTargetSuperClass({
+    type,
+    checker,
+    targetSuperClasses: ["Resource"],
+    ignoredClasses,
+  });
 };

--- a/src/core/cdk-construct/type-finder/index.ts
+++ b/src/core/cdk-construct/type-finder/index.ts
@@ -1,65 +1,45 @@
-import { Type } from "typescript";
+import { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
-import { findArrayElementType } from "../../../core/ts-type/finder/array-element";
-import { findGenericsTypeArgument } from "../../../core/ts-type/finder/generics-type-argument";
-import { isClassType } from "../../ts-type/checker/is-class";
 import { isResourceWithReadonlyInterface } from "../type-checker/is-resource-with-readonly-interface";
 
 /**
  * Recursively find the ts.Type to obtain type of CDK Construct class
  */
-export const findTypeOfCdkConstruct = (type: Type): Type | undefined => {
-  if (isClassType(type) && isResourceWithReadonlyInterface(type)) {
-    return type;
-  }
-  return (
-    findFromArray(type) ??
-    findFromGenerics(type) ??
-    findFromUnion(type) ??
-    findFromIntersection(type)
-  );
+export const findTypeOfCdkConstruct = (
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined => {
+  if (!type) return undefined;
+  if (isResourceWithReadonlyInterface(type, checker)) return type;
+  return findFromUnionOrIntersection(type, checker) ?? findFromTypeArguments(type, checker);
 };
 
 /**
- * Find Construct type from an array type (e.g. s3.Bucket[])
+ * Find Construct type from a union or intersection type
+ * @example s3.Bucket | string, s3.Bucket & { customProp: string }
  */
-const findFromArray = (type: Type): Type | undefined => {
-  const arrElementType = findArrayElementType(type);
-  if (!arrElementType) return undefined;
+const findFromUnionOrIntersection = (
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined => {
+  if (!checker.isUnionType(type) && !checker.isIntersectionType(type)) return undefined;
 
-  return findTypeOfCdkConstruct(arrElementType);
-};
-
-/**
- * Find Construct type from a generics type (e.g. Array<s3.Bucket>, Promise<s3.Bucket[]>)
- */
-const findFromGenerics = (type: Type): Type | undefined => {
-  const genericsArgument = findGenericsTypeArgument(type);
-  if (!genericsArgument) return undefined;
-
-  return findTypeOfCdkConstruct(genericsArgument);
-};
-
-/**
- * Find Construct type from a union type (e.g. s3.Bucket | string)
- */
-const findFromUnion = (type: Type): Type | undefined => {
-  if (!type.isUnion()) return undefined;
-
-  for (const unionType of type.types) {
-    const foundType = findTypeOfCdkConstruct(unionType);
+  for (const member of checker.getTypesOfType(type)) {
+    const foundType = findTypeOfCdkConstruct(member, checker);
     if (foundType) return foundType;
   }
 };
 
 /**
- * Find Construct type from an intersection type (e.g. s3.Bucket & { customProp: string })
+ * Find Construct type from a generics/array type
+ * @example s3.Bucket[], Array<s3.Bucket>, Promise<s3.Bucket[]>
  */
-const findFromIntersection = (type: Type): Type | undefined => {
-  if (!type.isIntersection()) return undefined;
-
-  for (const intersectionType of type.types) {
-    const foundType = findTypeOfCdkConstruct(intersectionType);
+const findFromTypeArguments = (
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined => {
+  for (const arg of checker.getTypeArguments(type)) {
+    const foundType = findTypeOfCdkConstruct(arg, checker);
     if (foundType) return foundType;
   }
 };

--- a/src/core/ts-type/checker/is-extends-target-super-class.ts
+++ b/src/core/ts-type/checker/is-extends-target-super-class.ts
@@ -1,24 +1,35 @@
-import { Type } from "typescript";
+import { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
 /**
  * Check if the type extends target super class
  * @param type - The type to check
+ * @param checker - The type checker
  * @param targetSuperClasses - The target super classes
+ * @param ignoredClasses - Classes that inherit from target super class but do not want to be treated as target super class
  * @returns True if the type extends target super class, otherwise false
  */
-export const isExtendsFromTargetSuperClass = (
-  type: Type,
-  targetSuperClasses: string[],
-  typeCheckFunction: (type: Type) => boolean,
-): boolean => {
-  if (!type.symbol) return false;
+export const isExtendsFromTargetSuperClass = (args: {
+  type: CorsaType | undefined;
+  checker: CorsaTypeCheckerShape;
+  targetSuperClasses: string[];
+  ignoredClasses: readonly string[];
+}): boolean => {
+  const { type, checker, targetSuperClasses, ignoredClasses } = args;
 
-  // NOTE: Check if the current type ends in target super class
-  if (targetSuperClasses.some((suffix) => type.symbol.name === suffix)) {
-    return true;
-  }
+  if (!type) return false;
+  const name = checker.getSymbolOfType(type)?.name ?? "";
+
+  if (ignoredClasses.includes(name)) return false;
+  if (targetSuperClasses.includes(name)) return true;
 
   // NOTE: Check the base type
-  const baseTypes = type.getBaseTypes() ?? [];
-  return baseTypes.some((baseType) => typeCheckFunction(baseType));
+  const baseTypes = checker.getBaseTypes(type);
+  return baseTypes.some((baseType) =>
+    isExtendsFromTargetSuperClass({
+      type: baseType,
+      checker,
+      targetSuperClasses,
+      ignoredClasses,
+    }),
+  );
 };

--- a/src/core/ts-type/finder/constructor-property-name.ts
+++ b/src/core/ts-type/finder/constructor-property-name.ts
@@ -1,18 +1,18 @@
-import { isClassDeclaration, isConstructorDeclaration, Type } from "typescript";
+import { CorsaType, CorsaTypeCheckerShape, SignatureKind } from "corsa-oxlint";
 
 /**
  * Parses type to get the property names of the class constructor.
  * @returns The property names of the class constructor.
+ * @param type - The type to parse
+ * @param checker - The type checker
  */
-export const findConstructorPropertyNames = (type: Type): string[] => {
-  const declarations = type.symbol?.declarations;
-  if (!declarations?.length) return [];
+export const findConstructorPropertyNames = (
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
+): string[] => {
+  if (!type) return [];
+  const signatures = checker.getSignaturesOfType(type, SignatureKind.Construct)[0];
+  if (!signatures?.parameterSymbols) return [];
 
-  const classDeclaration = declarations[0];
-  if (!isClassDeclaration(classDeclaration)) return [];
-
-  const constructor = classDeclaration.members.find((member) => isConstructorDeclaration(member));
-  if (!constructor?.parameters.length) return [];
-
-  return constructor.parameters.map((param) => param.name.getText());
+  return signatures.parameterSymbols.map((symbol) => symbol.name);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ClassicConfig } from "@typescript-eslint/utils/ts-eslint";
+import type { Linter } from "eslint";
 
 import { configs } from "./configs";
 import { EslintFlatConfig } from "./configs/eslint/flat-config";
@@ -11,11 +11,11 @@ export interface EslintCdkPlugin {
   configs: Readonly<{
     classicRecommended: {
       plugins: ["awscdk"];
-      rules: ClassicConfig.RulesRecord;
+      rules: Linter.RulesRecord;
     };
     classicStrict: {
       plugins: ["awscdk"];
-      rules: ClassicConfig.RulesRecord;
+      rules: Linter.RulesRecord;
     };
     recommended: EslintFlatConfig;
     strict: EslintFlatConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ClassicConfig } from "@typescript-eslint/utils/ts-eslint";
 
 import { configs } from "./configs";
-import { FlatConfig } from "./configs/flat-config";
+import { EslintFlatConfig } from "./configs/eslint/flat-config";
 import { rules } from "./rules";
 
 export { configs, rules };
@@ -17,8 +17,8 @@ export interface EslintCdkPlugin {
       plugins: ["awscdk"];
       rules: ClassicConfig.RulesRecord;
     };
-    recommended: FlatConfig;
-    strict: FlatConfig;
+    recommended: EslintFlatConfig;
+    strict: EslintFlatConfig;
   }>;
 }
 

--- a/src/rules/construct-constructor-property.ts
+++ b/src/rules/construct-constructor-property.ts
@@ -1,10 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  ESTree,
-  ParserServices,
-  RuleContext,
-} from "corsa-oxlint";
+import { AST_NODE_TYPES, ESLintUtils, ESTree, ParserServices, RuleContext } from "corsa-oxlint";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
@@ -18,15 +12,11 @@ type ConstructorParam =
   | ESTree.RestElement
   | ESTree.TSParameterProperty;
 
-type ConstructorProperties = [
-  ConstructorParam,
-  ConstructorParam,
-  ConstructorParam | undefined,
-];
+type ConstructorProperties = [ConstructorParam, ConstructorParam, ConstructorParam | undefined];
 
 /**
  * Enforces that constructors of classes extending Construct have the property names 'scope, id' or 'scope, id, props'
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const constructConstructorProperty = createRule({
@@ -97,10 +87,7 @@ const checkFirstParamIsScope = (
   context: RuleContext,
   parserServices: ParserServices,
 ) => {
-  if (
-    firstParam.type !== AST_NODE_TYPES.Identifier ||
-    firstParam.name !== "scope"
-  ) {
+  if (firstParam.type !== AST_NODE_TYPES.Identifier || firstParam.name !== "scope") {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorProperty",
@@ -121,22 +108,13 @@ const checkFirstParamIsScope = (
 /**
  * Checks if the second parameter is named "id" and of type string
  */
-const checkSecondParamIsId = (
-  secondParam: ConstructorProperties[1],
-  context: RuleContext,
-) => {
-  if (
-    secondParam.type !== AST_NODE_TYPES.Identifier ||
-    secondParam.name !== "id"
-  ) {
+const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: RuleContext) => {
+  if (secondParam.type !== AST_NODE_TYPES.Identifier || secondParam.name !== "id") {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (
-    secondParam.typeAnnotation?.typeAnnotation.type !==
-    AST_NODE_TYPES.TSStringKeyword
-  ) {
+  } else if (secondParam.typeAnnotation?.typeAnnotation.type !== AST_NODE_TYPES.TSStringKeyword) {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorIdType",
@@ -147,15 +125,9 @@ const checkSecondParamIsId = (
 /**
  * Checks if the third parameter is named "props"
  */
-const checkThirdParamIsProps = (
-  thirdParam: ConstructorProperties[2],
-  context: RuleContext,
-) => {
+const checkThirdParamIsProps = (thirdParam: ConstructorProperties[2], context: RuleContext) => {
   if (!thirdParam) return;
-  if (
-    thirdParam.type !== AST_NODE_TYPES.Identifier ||
-    thirdParam.name !== "props"
-  ) {
+  if (thirdParam.type !== AST_NODE_TYPES.Identifier || thirdParam.name !== "props") {
     context.report({
       node: thirdParam,
       messageId: "invalidConstructorProperty",

--- a/src/rules/construct-constructor-property.ts
+++ b/src/rules/construct-constructor-property.ts
@@ -1,24 +1,27 @@
 import {
   AST_NODE_TYPES,
   ESLintUtils,
-  ParserServicesWithTypeInformation,
-  TSESLint,
-  TSESTree,
-} from "@typescript-eslint/utils";
+  ESTree,
+  ParserServices,
+  RuleContext,
+} from "corsa-oxlint";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
-type Context = TSESLint.RuleContext<
-  "invalidConstructorProperty" | "invalidConstructorType" | "invalidConstructorIdType",
-  []
->;
+type ConstructorParam =
+  | ESTree.BindingIdentifier
+  | ESTree.ObjectPattern
+  | ESTree.ArrayPattern
+  | ESTree.AssignmentPattern
+  | ESTree.RestElement
+  | ESTree.TSParameterProperty;
 
 type ConstructorProperties = [
-  TSESTree.Parameter,
-  TSESTree.Parameter,
-  TSESTree.Parameter | undefined,
+  ConstructorParam,
+  ConstructorParam,
+  ConstructorParam | undefined,
 ];
 
 /**
@@ -33,6 +36,7 @@ export const constructConstructorProperty = createRule({
     docs: {
       description:
         "Enforces that constructors of classes extending Construct have the property names 'scope, id' or 'scope, id, props'",
+      requiresTypeChecking: true,
     },
     messages: {
       invalidConstructorProperty:
@@ -47,10 +51,11 @@ export const constructConstructorProperty = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       ClassDeclaration(node) {
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructType(type)) return;
+        if (!isConstructType(type, checker)) return;
 
         const constructor = findConstructor(node);
         if (!constructor) return;
@@ -70,8 +75,8 @@ export const constructConstructorProperty = createRule({
  * Checks if the number of constructor properties is valid (at least 2)
  */
 const checkNumOfConstructorProperty = (
-  constructor: TSESTree.MethodDefinition,
-  context: Context,
+  constructor: ESTree.MethodDefinition,
+  context: RuleContext,
 ): ConstructorProperties | undefined => {
   const params = constructor.value.params;
   if (params.length < 2) {
@@ -89,15 +94,23 @@ const checkNumOfConstructorProperty = (
  */
 const checkFirstParamIsScope = (
   firstParam: ConstructorProperties[0],
-  context: Context,
-  parserServices: ParserServicesWithTypeInformation,
+  context: RuleContext,
+  parserServices: ParserServices,
 ) => {
-  if (firstParam.type !== AST_NODE_TYPES.Identifier || firstParam.name !== "scope") {
+  if (
+    firstParam.type !== AST_NODE_TYPES.Identifier ||
+    firstParam.name !== "scope"
+  ) {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (!isConstructType(parserServices.getTypeAtLocation(firstParam))) {
+  } else if (
+    !isConstructType(
+      parserServices.getTypeAtLocation(firstParam),
+      parserServices.program.getTypeChecker(),
+    )
+  ) {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorType",
@@ -108,13 +121,22 @@ const checkFirstParamIsScope = (
 /**
  * Checks if the second parameter is named "id" and of type string
  */
-const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Context) => {
-  if (secondParam.type !== AST_NODE_TYPES.Identifier || secondParam.name !== "id") {
+const checkSecondParamIsId = (
+  secondParam: ConstructorProperties[1],
+  context: RuleContext,
+) => {
+  if (
+    secondParam.type !== AST_NODE_TYPES.Identifier ||
+    secondParam.name !== "id"
+  ) {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (secondParam.typeAnnotation?.typeAnnotation.type !== AST_NODE_TYPES.TSStringKeyword) {
+  } else if (
+    secondParam.typeAnnotation?.typeAnnotation.type !==
+    AST_NODE_TYPES.TSStringKeyword
+  ) {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorIdType",
@@ -125,9 +147,15 @@ const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Co
 /**
  * Checks if the third parameter is named "props"
  */
-const checkThirdParamIsProps = (thirdParam: ConstructorProperties[2], context: Context) => {
+const checkThirdParamIsProps = (
+  thirdParam: ConstructorProperties[2],
+  context: RuleContext,
+) => {
   if (!thirdParam) return;
-  if (thirdParam.type !== AST_NODE_TYPES.Identifier || thirdParam.name !== "props") {
+  if (
+    thirdParam.type !== AST_NODE_TYPES.Identifier ||
+    thirdParam.name !== "props"
+  ) {
     context.report({
       node: thirdParam,
       messageId: "invalidConstructorProperty",

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,5 +1,5 @@
-import type { TSESLint } from "@typescript-eslint/utils";
-import type { Rule } from "eslint";
+import type { Rule as OxlintRule } from "corsa-oxlint";
+import type { Rule as EslintRule } from "eslint";
 
 import { constructConstructorProperty } from "./construct-constructor-property";
 import { noConstructInInterface } from "./no-construct-in-interface";
@@ -19,7 +19,7 @@ import { requireJSDoc } from "./require-jsdoc";
 import { requirePassingThis } from "./require-passing-this";
 import { requirePropsDefaultDoc } from "./require-props-default-doc";
 
-type RuleModule = TSESLint.RuleModule<string, readonly unknown[]> | Rule.RuleModule;
+type RuleModule = EslintRule.RuleModule | (OxlintRule & Record<string, unknown>);
 
 export const rules: Record<string, RuleModule> = {
   "construct-constructor-property": constructConstructorProperty,

--- a/src/rules/no-construct-in-interface.ts
+++ b/src/rules/no-construct-in-interface.ts
@@ -1,11 +1,11 @@
-import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
 
 /**
  * Enforces the use of interface types instead of CDK Construct types in interface properties
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noConstructInInterface = createRule({
@@ -14,6 +14,7 @@ export const noConstructInInterface = createRule({
     type: "problem",
     docs: {
       description: "Disallow CDK Construct types in interface properties",
+      requiresTypeChecking: true,
     },
     messages: {
       invalidInterfaceProperty:
@@ -24,6 +25,7 @@ export const noConstructInInterface = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       TSInterfaceDeclaration(node) {
         for (const property of node.body.body) {
@@ -35,7 +37,7 @@ export const noConstructInInterface = createRule({
           }
 
           const type = parserServices.getTypeAtLocation(property);
-          const result = findTypeOfCdkConstruct(type);
+          const result = findTypeOfCdkConstruct(type, checker);
 
           if (result) {
             context.report({
@@ -43,7 +45,7 @@ export const noConstructInInterface = createRule({
               messageId: "invalidInterfaceProperty",
               data: {
                 propertyName: property.key.name,
-                typeName: result.symbol.name,
+                typeName: checker.getSymbolOfType(result)?.name ?? "",
               },
             });
           }

--- a/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,25 +1,16 @@
-import {
-  ESLintUtils,
-  ParserServicesWithTypeInformation,
-  TSESLint,
-  TSESTree,
-} from "@typescript-eslint/utils";
+import { ESLintUtils, ParserServices, RuleContext } from "corsa-oxlint";
 
-import { findPublicPropertiesInClass } from "../core/ast-node/finder/public-property";
+import {
+  findPublicPropertiesInClass,
+  PublicProperty,
+} from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
 
-type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
-
-type PublicProperty = {
-  name: string;
-  node: TSESTree.Parameter | TSESTree.ClassElement;
-};
-
 /**
  * Disallow Construct types in public property of Construct
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noConstructInPublicPropertyOfConstruct = createRule({
@@ -28,6 +19,7 @@ export const noConstructInPublicPropertyOfConstruct = createRule({
     type: "problem",
     docs: {
       description: "Disallow Construct types in public property of Construct",
+      requiresTypeChecking: true,
     },
     messages: {
       invalidPublicPropertyOfConstruct:
@@ -38,10 +30,11 @@ export const noConstructInPublicPropertyOfConstruct = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       ClassDeclaration(node) {
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type)) return;
+        if (!isConstructOrStackType(type, checker)) return;
         const publicProperties = findPublicPropertiesInClass(node);
         for (const publicProperty of publicProperties) {
           validatePublicProperty(publicProperty, context, parserServices);
@@ -53,18 +46,19 @@ export const noConstructInPublicPropertyOfConstruct = createRule({
 
 const validatePublicProperty = (
   publicProperty: PublicProperty,
-  context: Context,
-  parserServices: ParserServicesWithTypeInformation,
+  context: RuleContext,
+  parserServices: ParserServices,
 ) => {
+  const checker = parserServices.program.getTypeChecker();
   const type = parserServices.getTypeAtLocation(publicProperty.node);
-  const constructType = findTypeOfCdkConstruct(type);
+  const constructType = findTypeOfCdkConstruct(type, checker);
   if (constructType) {
     context.report({
       node: publicProperty.node,
       messageId: "invalidPublicPropertyOfConstruct",
       data: {
         propertyName: publicProperty.name,
-        typeName: constructType.symbol.name,
+        typeName: checker.getSymbolOfType(constructType)?.name ?? "",
       },
     });
   }

--- a/src/rules/no-construct-stack-suffix.ts
+++ b/src/rules/no-construct-stack-suffix.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, ESTree, RuleContext } from "corsa-oxlint";
 
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
@@ -20,11 +20,9 @@ const defaultOption: Option = {
   disallowedSuffixes: [SUFFIX_TYPE.CONSTRUCT, SUFFIX_TYPE.STACK],
 };
 
-type Context = TSESLint.RuleContext<"invalidConstructId", Option[]>;
-
 /**
  * Enforces that Construct IDs do not end with 'Construct' or 'Stack' suffix
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noConstructStackSuffix = createRule({
@@ -33,6 +31,7 @@ export const noConstructStackSuffix = createRule({
     type: "problem",
     docs: {
       description: "Effort to avoid using 'Construct' and 'Stack' suffix in construct id.",
+      requiresTypeChecking: true,
     },
     messages: {
       invalidConstructId: "{{ classType }} ID '{{ id }}' should not include {{ suffix }} suffix.",
@@ -57,15 +56,16 @@ export const noConstructStackSuffix = createRule({
   defaultOptions: [defaultOption],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
-
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type) || node.arguments.length < 2) {
+        if (!isConstructOrStackType(type, checker) || node.arguments.length < 2) {
           return;
         }
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);
@@ -77,8 +77,8 @@ export const noConstructStackSuffix = createRule({
 /**
  * Validate that construct ID does not end with "Construct" or "Stack"
  */
-const validateConstructId = (node: TSESTree.NewExpression, context: Context): void => {
-  const options = context.options[0] ?? defaultOption;
+const validateConstructId = (node: ESTree.NewExpression, context: RuleContext): void => {
+  const options: Option = context.options[0] ?? defaultOption;
 
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];

--- a/src/rules/no-import-private.ts
+++ b/src/rules/no-import-private.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 /**
  * Disallow importing modules from private directories at different levels of the hierarchy.
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noImportPrivate: Rule.RuleModule = {

--- a/src/rules/no-mutable-property-of-props-interface.ts
+++ b/src/rules/no-mutable-property-of-props-interface.ts
@@ -4,7 +4,7 @@ import { createRule } from "../shared/create-rule";
 
 /**
  * Disallow mutable properties of Construct Props (interface)
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noMutablePropertyOfPropsInterface = createRule({

--- a/src/rules/no-mutable-property-of-props-interface.ts
+++ b/src/rules/no-mutable-property-of-props-interface.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES } from "corsa-oxlint";
 
 import { createRule } from "../shared/create-rule";
 

--- a/src/rules/no-mutable-public-property-of-construct.ts
+++ b/src/rules/no-mutable-public-property-of-construct.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, TSESLint } from "@typescript-eslint/utils";
+import { ESLintUtils, RuleContext } from "corsa-oxlint";
 
 import {
   findPublicPropertiesInClass,
@@ -7,11 +7,9 @@ import {
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { createRule } from "../shared/create-rule";
 
-type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
-
 /**
  * Disallow mutable public properties of Construct
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noMutablePublicPropertyOfConstruct = createRule({
@@ -20,6 +18,7 @@ export const noMutablePublicPropertyOfConstruct = createRule({
     type: "problem",
     docs: {
       description: "Disallow mutable public properties of Construct",
+      requiresTypeChecking: true,
     },
     fixable: "code",
     messages: {
@@ -31,12 +30,13 @@ export const noMutablePublicPropertyOfConstruct = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
 
     return {
       ClassDeclaration(node) {
         const sourceCode = context.sourceCode;
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type)) return;
+        if (!isConstructOrStackType(type, checker)) return;
 
         const publicProperties = findPublicPropertiesInClass(node);
         for (const property of publicProperties) {
@@ -53,8 +53,8 @@ export const noMutablePublicPropertyOfConstruct = createRule({
 
 const validatePublicProperty = (args: {
   publicProperty: PublicProperty;
-  context: Context;
-  sourceCode: Readonly<TSESLint.SourceCode>;
+  context: RuleContext;
+  sourceCode: RuleContext["sourceCode"];
 }) => {
   const { publicProperty, context, sourceCode } = args;
   if (publicProperty.node.readonly) return;

--- a/src/rules/no-parent-name-construct-id-match.ts
+++ b/src/rules/no-parent-name-construct-id-match.ts
@@ -1,11 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  ParserServicesWithTypeInformation,
-  TSESLint,
-  TSESTree,
-} from "@typescript-eslint/utils";
-
+import { AST_NODE_TYPES, ESLintUtils, ESTree, ParserServices, RuleContext } from "corsa-oxlint";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -19,21 +12,21 @@ const defaultOption: Option = {
   disallowContainingParentName: false,
 };
 
-type Context = TSESLint.RuleContext<"invalidConstructId", Option[]>;
-
-type ValidateStatementArgs<T extends TSESTree.Statement> = {
+// FIXME: use ESTree.Statement instead of ESTree.Node
+type ValidateStatementArgs<T extends ESTree.Node> = {
   statement: T;
   parentClassName: string;
-  context: Context;
-  parserServices: ParserServicesWithTypeInformation;
+  context: RuleContext;
+  parserServices: ParserServices;
   option: Option;
 };
 
-type ValidateExpressionArgs<T extends TSESTree.Expression> = {
+// FIXME: use ESTree.Expression instead of ESTree.Node
+type ValidateExpressionArgs<T extends ESTree.Node> = {
   expression: T;
   parentClassName: string;
-  context: Context;
-  parserServices: ParserServicesWithTypeInformation;
+  context: RuleContext;
+  parserServices: ParserServices;
   option: Option;
 };
 
@@ -68,14 +61,15 @@ export const noParentNameConstructIdMatch = createRule({
   },
   defaultOptions: [defaultOption],
 
-  create(context: Context) {
+  create(context) {
     const option = context.options[0] || defaultOption;
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       ClassBody(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructOrStackType(type)) return;
+        if (!isConstructOrStackType(type, checker)) return;
 
         const parent = node.parent;
         if (parent?.type !== AST_NODE_TYPES.ClassDeclaration) return;
@@ -115,7 +109,8 @@ const validateConstructorBody = ({
   context,
   parserServices,
   option,
-}: ValidateExpressionArgs<TSESTree.FunctionExpression>): void => {
+}: ValidateExpressionArgs<ESTree.MethodDefinition["value"]>): void => {
+  if(!expression.body) return;
   for (const statement of expression.body.body) {
     switch (statement.type) {
       case AST_NODE_TYPES.VariableDeclaration: {
@@ -180,7 +175,7 @@ const traverseStatements = ({
   context,
   parserServices,
   option,
-}: ValidateStatementArgs<TSESTree.Statement>) => {
+}: ValidateStatementArgs<ESTree.Node>) => {
   switch (statement.type) {
     case AST_NODE_TYPES.BlockStatement: {
       for (const body of statement.body) {
@@ -232,7 +227,7 @@ const validateStatement = ({
   context,
   parserServices,
   option,
-}: ValidateStatementArgs<TSESTree.Statement>): void => {
+}: ValidateStatementArgs<ESTree.Node>): void => {
   switch (statement.type) {
     case AST_NODE_TYPES.VariableDeclaration: {
       const newExpression = statement.declarations[0].init;
@@ -291,7 +286,7 @@ const validateIfStatement = ({
   context,
   parserServices,
   option,
-}: ValidateStatementArgs<TSESTree.IfStatement>): void => {
+}: ValidateStatementArgs<ESTree.IfStatement>): void => {
   traverseStatements({
     context,
     parentClassName,
@@ -311,7 +306,7 @@ const validateSwitchStatement = ({
   context,
   parserServices,
   option,
-}: ValidateStatementArgs<TSESTree.SwitchStatement>): void => {
+}: ValidateStatementArgs<ESTree.SwitchStatement>): void => {
   for (const caseStatement of statement.cases) {
     for (const _consequent of caseStatement.consequent) {
       traverseStatements({
@@ -334,7 +329,7 @@ const validateConstructId = ({
   parentClassName,
   parserServices,
   option,
-}: ValidateExpressionArgs<TSESTree.NewExpression>): void => {
+}: ValidateExpressionArgs<ESTree.NewExpression>): void => {
   const type = parserServices.getTypeAtLocation(expression);
 
   if (expression.arguments.length < 2) return;
@@ -348,7 +343,7 @@ const validateConstructId = ({
   const formattedConstructId = toPascalCase(secondArg.value);
   const formattedParentClassName = toPascalCase(parentClassName);
 
-  if (!isConstructType(type)) return;
+  if (!isConstructType(type, parserServices.program.getTypeChecker())) return;
 
   if (
     option.disallowContainingParentName &&

--- a/src/rules/no-parent-name-construct-id-match.ts
+++ b/src/rules/no-parent-name-construct-id-match.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, ESLintUtils, ESTree, ParserServices, RuleContext } from "corsa-oxlint";
+
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -110,7 +111,7 @@ const validateConstructorBody = ({
   parserServices,
   option,
 }: ValidateExpressionArgs<ESTree.MethodDefinition["value"]>): void => {
-  if(!expression.body) return;
+  if (!expression.body) return;
   for (const statement of expression.body.body) {
     switch (statement.type) {
       case AST_NODE_TYPES.VariableDeclaration: {

--- a/src/rules/no-parent-name-construct-id-match.ts
+++ b/src/rules/no-parent-name-construct-id-match.ts
@@ -32,7 +32,7 @@ type ValidateExpressionArgs<T extends ESTree.Node> = {
 
 /**
  * Enforce that construct IDs does not match the parent construct name.
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noParentNameConstructIdMatch = createRule({

--- a/src/rules/no-unused-props/index.ts
+++ b/src/rules/no-unused-props/index.ts
@@ -17,7 +17,7 @@ type Context = TSESLint.RuleContext<"unusedProp", []>;
 
 /**
  * Enforces that all properties defined in props type are used within the constructor
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noUnusedProps = createRule({

--- a/src/rules/no-unused-props/index.ts
+++ b/src/rules/no-unused-props/index.ts
@@ -1,19 +1,17 @@
 import {
   AST_NODE_TYPES,
+  CorsaType,
   ESLintUtils,
-  ParserServicesWithTypeInformation,
-  TSESLint,
-  TSESTree,
-} from "@typescript-eslint/utils";
-import { Type } from "typescript";
+  ESTree,
+  ParserServices,
+  RuleContext,
+} from "corsa-oxlint";
 
 import { findConstructor } from "../../core/ast-node/finder/constructor";
 import { isConstructType } from "../../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../../shared/create-rule";
 import { PropsUsageAnalyzer } from "./props-usage-analyzer";
 import { IPropsUsageTracker, PropsUsageTracker } from "./props-usage-tracker";
-
-type Context = TSESLint.RuleContext<"unusedProp", []>;
 
 /**
  * Enforces that all properties defined in props type are used within the constructor
@@ -36,13 +34,14 @@ export const noUnusedProps = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
 
     return {
       ClassDeclaration(node) {
         if (node.abstract) return;
 
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructType(type)) return;
+        if (!isConstructType(type, checker)) return;
 
         const constructor = findConstructor(node);
         if (!constructor) return;
@@ -51,7 +50,7 @@ export const noUnusedProps = createRule({
         if (!propsParam) return;
         if (isPropsUsedInSuperCall(constructor, propsParam.node.name)) return;
 
-        const tracker = new PropsUsageTracker(propsParam.type);
+        const tracker = new PropsUsageTracker(propsParam.type, checker);
         const analyzer = new PropsUsageAnalyzer(tracker);
 
         analyzer.analyze(constructor, propsParam.node);
@@ -62,9 +61,9 @@ export const noUnusedProps = createRule({
 });
 
 const getPropsParam = (
-  constructor: TSESTree.MethodDefinition,
-  parserServices: ParserServicesWithTypeInformation,
-): { node: TSESTree.Identifier; type: Type } | null => {
+  constructor: ESTree.MethodDefinition,
+  parserServices: ParserServices,
+): { node: ESTree.BindingIdentifier; type: CorsaType } | null => {
   const params = constructor.value.params;
   if (params.length < 3) return null;
 
@@ -75,9 +74,12 @@ const getPropsParam = (
   // ++++++++++++++++++++++++++++++++++++
   if (propsParam.type !== AST_NODE_TYPES.Identifier) return null;
 
+  const type = parserServices.getTypeAtLocation(propsParam);
+  if (!type) return null;
+
   return {
     node: propsParam,
-    type: parserServices.getTypeAtLocation(propsParam),
+    type,
   };
 };
 
@@ -96,7 +98,7 @@ const getPropsParam = (
  * @returns True if props are used in super call, false otherwise
  */
 const isPropsUsedInSuperCall = (
-  constructor: TSESTree.MethodDefinition,
+  constructor: ESTree.MethodDefinition,
   propsPropertyName: string,
 ): boolean => {
   if (constructor.kind !== "constructor") return false;
@@ -112,7 +114,7 @@ const isPropsUsedInSuperCall = (
       continue;
     }
 
-    const visitNode = (node: TSESTree.Node, propsName: string): boolean => {
+    const visitNode = (node: ESTree.Node, propsName: string): boolean => {
       const nodeValue = node.type === AST_NODE_TYPES.Property ? node.value : node;
       switch (nodeValue.type) {
         case AST_NODE_TYPES.Identifier: {
@@ -144,8 +146,8 @@ const isPropsUsedInSuperCall = (
  */
 const reportUnusedProperties = (
   tracker: IPropsUsageTracker,
-  propsParam: TSESTree.Parameter,
-  context: Context,
+  propsParam: ESTree.BindingIdentifier,
+  context: RuleContext,
 ): void => {
   for (const propName of tracker.getUnusedProperties()) {
     context.report({

--- a/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { IPropsUsageTracker } from "./props-usage-tracker";
 import {
@@ -10,7 +10,7 @@ import {
 } from "./visitor";
 
 export interface IPropsUsageAnalyzer {
-  analyze(constructor: TSESTree.MethodDefinition, propsParam: TSESTree.Identifier): void;
+  analyze(constructor: ESTree.MethodDefinition, propsParam: ESTree.Identifier): void;
 }
 
 export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
@@ -20,11 +20,12 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     this.tracker = tracker;
   }
 
-  analyze(constructor: TSESTree.MethodDefinition, propsParam: TSESTree.Identifier): void {
+  analyze(constructor: ESTree.MethodDefinition, propsParam: ESTree.Identifier): void {
     const constructorBody = constructor.value.body;
     const classNode = constructor.parent;
     const propsParamName = propsParam.name;
     if (!constructorBody) return;
+    if (!classNode || classNode.type !== AST_NODE_TYPES.ClassBody) return;
 
     this.checkUsageForDirectAccess(constructorBody, propsParamName);
     this.checkUsageForAliasAccess(constructorBody, propsParamName);
@@ -51,7 +52,7 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @param propsParamName - The name of the props parameter (e.g., "props")
    */
   private checkUsageForDirectAccess(
-    constructorBody: TSESTree.BlockStatement,
+    constructorBody: ESTree.BlockStatement,
     propsParamName: string,
   ): void {
     const directVisitor = new DirectPropsUsageVisitor(this.tracker, propsParamName);
@@ -77,7 +78,7 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @param propsParamName - The name of the props parameter (e.g., "props")
    */
   private checkUsageForAliasAccess(
-    constructorBody: TSESTree.BlockStatement,
+    constructorBody: ESTree.BlockStatement,
     propsParamName: string,
   ): void {
     const aliasVisitor = new PropsAliasVisitor(this.tracker, propsParamName);
@@ -111,8 +112,8 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @param propsParamName - The name of the props parameter (e.g., "props")
    */
   private checkUsageForInstanceVariable(
-    classBody: TSESTree.ClassBody,
-    constructor: TSESTree.MethodDefinition,
+    classBody: ESTree.ClassBody,
+    constructor: ESTree.MethodDefinition,
     propsParamName: string,
   ) {
     if (!constructor.value.body) return;
@@ -149,8 +150,8 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @param propsParamName - The name of the props parameter (e.g., "props")
    */
   private checkUsageForPrivateMethodsCalledFromConstructor(
-    constructorBody: TSESTree.BlockStatement,
-    classBody: TSESTree.ClassBody,
+    constructorBody: ESTree.BlockStatement,
+    classBody: ESTree.ClassBody,
     propsParamName: string,
   ): void {
     // NOTE: Collect method calls in constructor
@@ -192,7 +193,7 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @returns Array of method call info with method names and argument indices where props appears
    */
   private collectMethodCallsWithProps(
-    body: TSESTree.BlockStatement,
+    body: ESTree.BlockStatement,
     propsParamName: string,
   ): { methodName: string; propsArgIndices: number[] }[] {
     const visitor = new MethodCallCollectorVisitor(propsParamName);
@@ -231,7 +232,7 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @returns The instance variable name (e.g., "myProps") or null if not found
    */
   private findPropsInstanceVariable(
-    body: TSESTree.BlockStatement,
+    body: ESTree.BlockStatement,
     propsParamName: string,
   ): string | null {
     for (const statement of body.body) {
@@ -282,16 +283,17 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
    * @returns The MethodDefinition node or null if not found
    */
   private findMethodDefinition(
-    classBody: TSESTree.ClassBody,
+    classBody: ESTree.ClassBody,
     methodName: string,
-  ): TSESTree.MethodDefinition | null {
+  ): ESTree.MethodDefinition | null {
     for (const member of classBody.body) {
       if (
         member.type === AST_NODE_TYPES.MethodDefinition &&
         member.key.type === AST_NODE_TYPES.Identifier &&
         member.key.name === methodName
       ) {
-        return member;
+        // FIXME: not use `as` assertion
+        return member as ESTree.MethodDefinition;
       }
     }
     return null;

--- a/src/rules/no-unused-props/props-usage-tracker.ts
+++ b/src/rules/no-unused-props/props-usage-tracker.ts
@@ -56,10 +56,10 @@ export class PropsUsageTracker implements IPropsUsageTracker {
   private readonly checker: CorsaTypeCheckerShape;
 
   constructor(propType: CorsaType, checker: CorsaTypeCheckerShape) {
+    this.checker = checker;
     this.propUsageMap = new Map<string, boolean>(
       this.getPropsPropertyNames(propType).map((name) => [name, false]),
     );
-    this.checker = checker;
   }
 
   public getUnusedProperties(): string[] {

--- a/src/rules/no-unused-props/props-usage-tracker.ts
+++ b/src/rules/no-unused-props/props-usage-tracker.ts
@@ -1,5 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
-import { Type } from "typescript";
+import { AST_NODE_TYPES, CorsaType, CorsaTypeCheckerShape, ESTree } from "corsa-oxlint";
 
 import { findPropertyNames } from "../../core/ast-node/finder/property-name";
 
@@ -10,7 +9,7 @@ export interface IPropsUsageTracker {
    * @param node The member expression node.
    * @param propsParamName The name of the property being tracked.
    */
-  markAsUsedForMemberExpression(node: TSESTree.MemberExpression, propsParamName: string): void;
+  markAsUsedForMemberExpression(node: ESTree.MemberExpression, propsParamName: string): void;
 
   /**
    * Marks a property as used when it is accessed in a member expression.
@@ -18,7 +17,7 @@ export interface IPropsUsageTracker {
    * @param node The member expression node.
    * @param propsParamName The name of the property being tracked.
    */
-  markAsUsedForVariableDeclarator(node: TSESTree.VariableDeclarator, propsParamName: string): void;
+  markAsUsedForVariableDeclarator(node: ESTree.VariableDeclarator, propsParamName: string): void;
 
   /**
    * Marks a property as used when it is assigned in an expression.
@@ -27,7 +26,7 @@ export interface IPropsUsageTracker {
    * @param propsParamName The name of the property being tracked.
    */
   markAsUsedForAssignmentExpression(
-    node: TSESTree.AssignmentExpression,
+    node: ESTree.AssignmentExpression,
     propsParamName: string,
   ): void;
 
@@ -54,11 +53,13 @@ export interface IPropsUsageTracker {
 
 export class PropsUsageTracker implements IPropsUsageTracker {
   private propUsageMap: Map<string, boolean>;
+  private readonly checker: CorsaTypeCheckerShape;
 
-  constructor(propType: Type) {
+  constructor(propType: CorsaType, checker: CorsaTypeCheckerShape) {
     this.propUsageMap = new Map<string, boolean>(
       this.getPropsPropertyNames(propType).map((name) => [name, false]),
     );
+    this.checker = checker;
   }
 
   public getUnusedProperties(): string[] {
@@ -81,7 +82,7 @@ export class PropsUsageTracker implements IPropsUsageTracker {
   }
 
   public markAsUsedForMemberExpression(
-    node: TSESTree.MemberExpression,
+    node: ESTree.MemberExpression,
     propsParamName: string,
   ): void {
     // NOTE: Check for props.propertyName or props?.propertyName pattern
@@ -108,7 +109,7 @@ export class PropsUsageTracker implements IPropsUsageTracker {
   }
 
   public markAsUsedForVariableDeclarator(
-    node: TSESTree.VariableDeclarator,
+    node: ESTree.VariableDeclarator,
     propsParamName: string,
   ): void {
     // NOTE: Check for destructuring assignment: const { prop1, prop2 } = props
@@ -127,7 +128,7 @@ export class PropsUsageTracker implements IPropsUsageTracker {
   }
 
   public markAsUsedForAssignmentExpression(
-    node: TSESTree.AssignmentExpression,
+    node: ESTree.AssignmentExpression,
     propsParamName: string,
   ): void {
     // NOTE: Check for this.property = props.property pattern
@@ -149,26 +150,16 @@ export class PropsUsageTracker implements IPropsUsageTracker {
   /**
    * Gets the property names from the props type
    */
-  private getPropsPropertyNames(propsType: Type): string[] {
+  private getPropsPropertyNames(propsType: CorsaType): string[] {
     const isInternalProperty = (propertyName: string): boolean =>
       propertyName.startsWith("_") ||
       propertyName === "constructor" ||
       propertyName === "prototype";
 
-    const typeProperties = propsType.getProperties();
-    if (typeProperties.length) {
-      return typeProperties.reduce<string[]>(
-        (acc, prop) => (!isInternalProperty(prop.name) ? [...acc, prop.name] : acc),
-        [],
-      );
-    }
-
-    const symbol = propsType.getSymbol();
-    if (!symbol?.members) return [];
-
-    return Array.from(symbol.members.keys()).reduce<string[]>((acc, key) => {
-      const name = String(key);
-      return !isInternalProperty(name) ? [...acc, name] : acc;
-    }, []);
+    const typeProperties = this.checker.getPropertiesOfType(propsType);
+    return typeProperties.reduce<string[]>(
+      (acc, prop) => (!isInternalProperty(prop.name) ? [...acc, prop.name] : acc),
+      [],
+    );
   }
 }

--- a/src/rules/no-unused-props/visitor/direct-props-usage-visitor.ts
+++ b/src/rules/no-unused-props/visitor/direct-props-usage-visitor.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
@@ -29,19 +29,19 @@ export class DirectPropsUsageVisitor implements INodeVisitor {
     private readonly propsParamName: string,
   ) {}
 
-  visitMemberExpression(node: TSESTree.MemberExpression): void {
+  visitMemberExpression(node: ESTree.MemberExpression): void {
     this.tracker.markAsUsedForMemberExpression(node, this.propsParamName);
   }
 
-  visitVariableDeclarator(node: TSESTree.VariableDeclarator): void {
+  visitVariableDeclarator(node: ESTree.VariableDeclarator): void {
     this.tracker.markAsUsedForVariableDeclarator(node, this.propsParamName);
   }
 
-  visitAssignmentExpression(node: TSESTree.AssignmentExpression): void {
+  visitAssignmentExpression(node: ESTree.AssignmentExpression): void {
     this.tracker.markAsUsedForAssignmentExpression(node, this.propsParamName);
   }
 
-  visitIdentifier(node: TSESTree.Identifier): void {
+  visitIdentifier(node: ESTree.Identifier): void {
     /**
      * Handles cases where the props identifier is used as a whole value.
      *
@@ -99,7 +99,7 @@ export class DirectPropsUsageVisitor implements INodeVisitor {
     switch (parent.type) {
       // NOTE: Pattern 1: External function call
       case AST_NODE_TYPES.CallExpression: {
-        if (!parent.arguments.includes(node)) return;
+        if (!parent.arguments.some((arg) => arg === node)) return;
         if (
           parent.callee.type === AST_NODE_TYPES.MemberExpression &&
           parent.callee.object.type === AST_NODE_TYPES.ThisExpression
@@ -122,7 +122,7 @@ export class DirectPropsUsageVisitor implements INodeVisitor {
       // NOTE: Pattern 3: Array element
       case AST_NODE_TYPES.ArrayExpression: {
         // NOTE: [props] - props as a whole
-        if (parent.elements.includes(node)) {
+        if (parent.elements.some((el) => el === node)) {
           this.tracker.markAllAsUsed();
         }
         return;

--- a/src/rules/no-unused-props/visitor/instance-variable-usage-visitor.ts
+++ b/src/rules/no-unused-props/visitor/instance-variable-usage-visitor.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
@@ -35,7 +35,7 @@ export class InstanceVariableUsageVisitor implements INodeVisitor {
     private readonly instanceVarName: string,
   ) {}
 
-  visitMemberExpression(node: TSESTree.MemberExpression): void {
+  visitMemberExpression(node: ESTree.MemberExpression): void {
     // ===========================================================================
     // Pattern 1: Property access - this.instanceVarName.propertyName
     // ===========================================================================

--- a/src/rules/no-unused-props/visitor/interface/node-visitor.ts
+++ b/src/rules/no-unused-props/visitor/interface/node-visitor.ts
@@ -1,9 +1,9 @@
-import { TSESTree } from "@typescript-eslint/utils";
+import { ESTree } from "corsa-oxlint";
 
 export interface INodeVisitor {
-  visitMemberExpression?(node: TSESTree.MemberExpression): void;
-  visitVariableDeclarator?(node: TSESTree.VariableDeclarator): void;
-  visitAssignmentExpression?(node: TSESTree.AssignmentExpression): void;
-  visitIdentifier?(node: TSESTree.Identifier): void;
-  visitCallExpression?(node: TSESTree.CallExpression): void;
+  visitMemberExpression?(node: ESTree.MemberExpression): void;
+  visitVariableDeclarator?(node: ESTree.VariableDeclarator): void;
+  visitAssignmentExpression?(node: ESTree.AssignmentExpression): void;
+  visitIdentifier?(node: ESTree.Identifier): void;
+  visitCallExpression?(node: ESTree.CallExpression): void;
 }

--- a/src/rules/no-unused-props/visitor/method-call-collector-visitor.ts
+++ b/src/rules/no-unused-props/visitor/method-call-collector-visitor.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { INodeVisitor } from "./interface/node-visitor";
 
@@ -32,7 +32,7 @@ export class MethodCallCollectorVisitor implements INodeVisitor {
     this.propsParamName = propsParamName;
   }
 
-  visitCallExpression(node: TSESTree.CallExpression): void {
+  visitCallExpression(node: ESTree.CallExpression): void {
     // NOTE: Check for this.methodName(...) pattern
     if (
       node.callee.type !== AST_NODE_TYPES.MemberExpression ||

--- a/src/rules/no-unused-props/visitor/props-alias-visitor.ts
+++ b/src/rules/no-unused-props/visitor/props-alias-visitor.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
@@ -27,7 +27,7 @@ export class PropsAliasVisitor implements INodeVisitor {
     private readonly propsParamName: string,
   ) {}
 
-  visitMemberExpression(node: TSESTree.MemberExpression): void {
+  visitMemberExpression(node: ESTree.MemberExpression): void {
     this.tracker.markAsUsedForMemberExpression(node, this.propsParamName);
     /**
      * NOTE: Check if the object is an alias of props
@@ -45,7 +45,7 @@ export class PropsAliasVisitor implements INodeVisitor {
     }
   }
 
-  visitIdentifier(node: TSESTree.Identifier): void {
+  visitIdentifier(node: ESTree.Identifier): void {
     /**
      * Handles alias registration for props.
      *

--- a/src/rules/no-unused-props/visitor/traverse-nodes.ts
+++ b/src/rules/no-unused-props/visitor/traverse-nodes.ts
@@ -1,9 +1,9 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESTree } from "corsa-oxlint";
 
 import { findChildNodes } from "../../../core/ast-node/finder/child-nodes";
 import { INodeVisitor } from "./interface/node-visitor";
 
-export const traverseNodes = (node: TSESTree.Node, visitor: INodeVisitor): void => {
+export const traverseNodes = (node: ESTree.Node, visitor: INodeVisitor): void => {
   switch (node.type) {
     case AST_NODE_TYPES.MemberExpression: {
       visitor.visitMemberExpression?.(node);

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -41,7 +41,8 @@ export const noVariableConstructId = createRule({
           : undefined;
         if (enclosingClassType && !isConstructOrStackType(enclosingClassType, checker)) return;
 
-        const constructorPropertyNames = findConstructorPropertyNames(type, checker);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -1,12 +1,10 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, ESTree, RuleContext } from "corsa-oxlint";
 
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
-
-type Context = TSESLint.RuleContext<"invalidConstructId", []>;
 
 /**
  * Enforce using literal strings for Construct ID.
@@ -19,6 +17,7 @@ export const noVariableConstructId = createRule({
     type: "problem",
     docs: {
       description: `Enforce using literal strings for Construct ID.`,
+      requiresTypeChecking: true,
     },
     messages: {
       invalidConstructId: "Shouldn't use a parameter as a Construct ID.",
@@ -28,20 +27,21 @@ export const noVariableConstructId = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type) || node.arguments.length < 2) return;
+        if (!isConstructType(type, checker) || node.arguments.length < 2) return;
 
         // NOTE: Skip when inside a class that is not Construct/Stack
         const enclosingClass = findEnclosingClass(node);
         const enclosingClassType = enclosingClass
           ? parserServices.getTypeAtLocation(enclosingClass)
           : undefined;
-        if (enclosingClassType && !isConstructOrStackType(enclosingClassType)) return;
+        if (enclosingClassType && !isConstructOrStackType(enclosingClassType, checker)) return;
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const constructorPropertyNames = findConstructorPropertyNames(type, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);
@@ -53,7 +53,7 @@ export const noVariableConstructId = createRule({
 /**
  * Check if the construct ID is a literal string
  */
-const validateConstructId = (node: TSESTree.NewExpression, context: Context) => {
+const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) => {
   if (node.arguments.length < 2 || shouldSkipIdValidation(node)) return;
 
   // NOTE: Treat the second argument as ID
@@ -79,7 +79,7 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
  * Check if construct ID validation should be skipped for a node.
  * Skip if it is inside a loop statement, non-constructor method, or arrow function.
  */
-const shouldSkipIdValidation = (node: TSESTree.Node): boolean => {
+const shouldSkipIdValidation = (node: ESTree.Node): boolean => {
   let current = node.parent;
   while (current) {
     // Constructs defined in loops require variable IDs

--- a/src/rules/no-variable-construct-id.ts
+++ b/src/rules/no-variable-construct-id.ts
@@ -8,7 +8,7 @@ import { createRule } from "../shared/create-rule";
 
 /**
  * Enforce using literal strings for Construct ID.
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const noVariableConstructId = createRule({

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -25,6 +25,7 @@ export const pascalCaseConstructId = createRule({
     type: "problem",
     docs: {
       description: "Enforce PascalCase for Construct ID.",
+      requiresTypeChecking: true,
     },
     messages: {
       invalidConstructId: "Construct ID must be PascalCase.",

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -43,7 +43,8 @@ export const pascalCaseConstructId = createRule({
           return;
         }
 
-        const constructorPropertyNames = findConstructorPropertyNames(type, checker);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -16,7 +16,7 @@ type QuoteType = (typeof QUOTE_TYPE)[keyof typeof QUOTE_TYPE];
 /**
 /**
  * Enforce PascalCase for Construct ID.
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const pascalCaseConstructId = createRule({

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -1,5 +1,5 @@
-
 import { AST_NODE_TYPES, ESLintUtils, ESTree, RuleContext } from "corsa-oxlint";
+
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -11,7 +11,6 @@ const QUOTE_TYPE = {
 } as const;
 
 type QuoteType = (typeof QUOTE_TYPE)[keyof typeof QUOTE_TYPE];
-
 
 /**
 /**

--- a/src/rules/pascal-case-construct-id.ts
+++ b/src/rules/pascal-case-construct-id.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
+import { AST_NODE_TYPES, ESLintUtils, ESTree, RuleContext } from "corsa-oxlint";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -12,7 +12,6 @@ const QUOTE_TYPE = {
 
 type QuoteType = (typeof QUOTE_TYPE)[keyof typeof QUOTE_TYPE];
 
-type Context = TSESLint.RuleContext<"invalidConstructId", []>;
 
 /**
 /**
@@ -36,14 +35,15 @@ export const pascalCaseConstructId = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type) || node.arguments.length < 2) {
+        if (!isConstructOrStackType(type, checker) || node.arguments.length < 2) {
           return;
         }
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const constructorPropertyNames = findConstructorPropertyNames(type, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);
@@ -64,7 +64,7 @@ const isPascalCase = (str: string) => {
 /**
  * Check the construct ID is PascalCase
  */
-const validateConstructId = (node: TSESTree.NewExpression, context: Context) => {
+const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) => {
   if (node.arguments.length < 2) return;
 
   // NOTE: Treat the second argument as ID

--- a/src/rules/prefer-grants-property.ts
+++ b/src/rules/prefer-grants-property.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, ESLintUtils, ESTree } from "corsa-oxlint";
+
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 

--- a/src/rules/prefer-grants-property.ts
+++ b/src/rules/prefer-grants-property.ts
@@ -1,5 +1,4 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
-
+import { AST_NODE_TYPES, ESLintUtils, ESTree } from "corsa-oxlint";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -9,6 +8,7 @@ export const preferGrantsProperty = createRule({
     type: "suggestion",
     docs: {
       description: "Prefer using the grants property over grant* methods when available.",
+      requiresTypeChecking: true,
     },
     messages: {
       useGrantsProperty:
@@ -22,7 +22,7 @@ export const preferGrantsProperty = createRule({
     const checker = parserServices.program.getTypeChecker();
 
     return {
-      CallExpression(node: TSESTree.CallExpression) {
+      CallExpression(node: ESTree.CallExpression) {
         if (
           node.callee.type !== AST_NODE_TYPES.MemberExpression ||
           node.callee.property.type !== AST_NODE_TYPES.Identifier
@@ -36,20 +36,24 @@ export const preferGrantsProperty = createRule({
         const objectNode = node.callee.object;
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(objectNode);
         const type = checker.getTypeAtLocation(tsNode);
-        if (!isConstructType(type)) return;
+        if (!type || !isConstructType(type, checker)) return;
 
-        const grantsProperty = type.getProperty("grants");
+        const grantsProperty = checker.getPropertiesOfType(type).find((s) => s.name === "grants");
         if (!grantsProperty) return;
 
         const grantsType = checker.getTypeOfSymbolAtLocation(grantsProperty, tsNode);
-        const grantsTypeName = grantsType.symbol?.name;
+        if (!grantsType) return;
+
+        const grantsTypeName = checker.getSymbolOfType(grantsType)?.name;
         if (!grantsTypeName?.endsWith("Grants")) return;
 
         const convertedMethodName = methodName
           .replace(/^grant/, "")
           .replace(/^./, (c) => c.toLowerCase());
 
-        const suggestedMethod = grantsType.getProperty(convertedMethodName);
+        const suggestedMethod = checker
+          .getPropertiesOfType(grantsType)
+          .find((s) => s.name === convertedMethodName);
         if (!suggestedMethod) return;
 
         const objectName =

--- a/src/rules/prevent-construct-id-collision.ts
+++ b/src/rules/prevent-construct-id-collision.ts
@@ -1,5 +1,5 @@
-
 import { AST_NODE_TYPES, ESLintUtils, ESTree, RuleContext } from "corsa-oxlint";
+
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -46,10 +46,7 @@ export const preventConstructIdCollision = createRule({
 /**
  * Validate whether a Construct ID is a literal inside a loop
  */
-const validateConstructIdInLoop = (
-  node: ESTree.NewExpression,
-  context: RuleContext,
-) => {
+const validateConstructIdInLoop = (node: ESTree.NewExpression, context: RuleContext) => {
   if (!isInsideLoop(node)) return;
 
   const secondArg = node.arguments[1];
@@ -99,8 +96,10 @@ const isInsideLoop = (node: ESTree.Node): boolean => {
     if (
       (current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
         current.type === AST_NODE_TYPES.FunctionExpression) &&
-        // FIXME: not use `as` assertion
-      isIterationMethodCallback(current as ESTree.ArrowFunctionExpression | ESTree.FunctionExpression)
+      // FIXME: not use `as` assertion
+      isIterationMethodCallback(
+        current as ESTree.ArrowFunctionExpression | ESTree.FunctionExpression,
+      )
     ) {
       return true;
     }

--- a/src/rules/prevent-construct-id-collision.ts
+++ b/src/rules/prevent-construct-id-collision.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
+import { AST_NODE_TYPES, ESLintUtils, ESTree, RuleContext } from "corsa-oxlint";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -15,6 +15,7 @@ export const preventConstructIdCollision = createRule({
     docs: {
       description:
         "Disallow using literal Construct IDs inside loops, which may cause ID collisions.",
+      requiresTypeChecking: true,
     },
     messages: {
       preventConstructIdCollision:
@@ -25,13 +26,15 @@ export const preventConstructIdCollision = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type) || node.arguments.length < 2) return;
+        if (!isConstructType(type, checker) || node.arguments.length < 2) return;
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructIdInLoop(node, context);
@@ -44,8 +47,8 @@ export const preventConstructIdCollision = createRule({
  * Validate whether a Construct ID is a literal inside a loop
  */
 const validateConstructIdInLoop = (
-  node: TSESTree.NewExpression,
-  context: Parameters<typeof preventConstructIdCollision.create>[0],
+  node: ESTree.NewExpression,
+  context: RuleContext,
 ) => {
   if (!isInsideLoop(node)) return;
 
@@ -78,7 +81,7 @@ const validateConstructIdInLoop = (
  * Detects for, for...in, for...of, while, do...while statements,
  * and callbacks of iteration methods (forEach, map, etc.)
  */
-const isInsideLoop = (node: TSESTree.Node): boolean => {
+const isInsideLoop = (node: ESTree.Node): boolean => {
   let current = node.parent;
   while (current) {
     // NOTE: Detect loop statements
@@ -96,7 +99,8 @@ const isInsideLoop = (node: TSESTree.Node): boolean => {
     if (
       (current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
         current.type === AST_NODE_TYPES.FunctionExpression) &&
-      isIterationMethodCallback(current)
+        // FIXME: not use `as` assertion
+      isIterationMethodCallback(current as ESTree.ArrowFunctionExpression | ESTree.FunctionExpression)
     ) {
       return true;
     }
@@ -130,7 +134,7 @@ const ITERATION_METHODS = new Set([
  * Check whether an arrow function or function expression is a callback of an iteration method
  */
 const isIterationMethodCallback = (
-  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  node: ESTree.ArrowFunctionExpression | ESTree.FunctionExpression,
 ): boolean => {
   const parent = node.parent;
   if (parent?.type !== AST_NODE_TYPES.CallExpression) return false;

--- a/src/rules/props-name-convention.ts
+++ b/src/rules/props-name-convention.ts
@@ -1,6 +1,5 @@
-
-
 import { AST_NODE_TYPES, ESLintUtils, ESTree } from "corsa-oxlint";
+
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
@@ -13,7 +12,7 @@ type ConstructorParam =
   | ESTree.AssignmentPattern
   | ESTree.RestElement
   | ESTree.TSParameterProperty;
-  
+
 /**
  * Enforces a naming convention for props interfaces in Construct classes
  * @param context - The rule context

--- a/src/rules/props-name-convention.ts
+++ b/src/rules/props-name-convention.ts
@@ -1,9 +1,19 @@
-import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
+
+import { AST_NODE_TYPES, ESLintUtils, ESTree } from "corsa-oxlint";
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
+// FIXME: delete this type
+type ConstructorParam =
+  | ESTree.BindingIdentifier
+  | ESTree.ObjectPattern
+  | ESTree.ArrayPattern
+  | ESTree.AssignmentPattern
+  | ESTree.RestElement
+  | ESTree.TSParameterProperty;
+  
 /**
  * Enforces a naming convention for props interfaces in Construct classes
  * @param context - The rule context provided by ESLint
@@ -15,6 +25,7 @@ export const propsNameConvention = createRule({
     type: "problem",
     docs: {
       description: "Enforce props interface name to follow ${ConstructName}Props format",
+      requiresTypeChecking: true,
     },
     schema: [],
     messages: {
@@ -25,18 +36,19 @@ export const propsNameConvention = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       ClassDeclaration(node) {
         if (!node.id || !node.superClass) return;
 
         const type = parserServices.getTypeAtLocation(node.superClass);
-        if (!isConstructType(type)) return;
+        if (!isConstructType(type, checker)) return;
 
         // NOTE: check constructor parameter
         const constructor = findConstructor(node);
         if (!constructor) return;
 
-        const propsParam = constructor.value.params?.[2];
+        const propsParam: ConstructorParam | undefined = constructor.value.params?.[2];
         if (propsParam?.type !== AST_NODE_TYPES.Identifier) return;
 
         const typeAnnotation = propsParam.typeAnnotation;

--- a/src/rules/props-name-convention.ts
+++ b/src/rules/props-name-convention.ts
@@ -16,7 +16,7 @@ type ConstructorParam =
   
 /**
  * Enforces a naming convention for props interfaces in Construct classes
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const propsNameConvention = createRule({

--- a/src/rules/require-jsdoc.ts
+++ b/src/rules/require-jsdoc.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES, AST_TOKEN_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
+import { AST_NODE_TYPES, AST_TOKEN_TYPES, ESLintUtils } from "corsa-oxlint";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -25,13 +25,14 @@ export const requireJSDoc = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       TSPropertySignature(node) {
         if (node.key.type !== AST_NODE_TYPES.Identifier) return;
 
         // NOTE: Check if the parent is an interface
         const parent = node.parent.parent;
-        if (parent.type !== AST_NODE_TYPES.TSInterfaceDeclaration) return;
+        if (parent?.type !== AST_NODE_TYPES.TSInterfaceDeclaration) return;
 
         // NOTE: Check if the interface name ends with 'Props'
         if (!parent.id.name.endsWith("Props")) return;
@@ -73,7 +74,7 @@ export const requireJSDoc = createRule({
         // NOTE: Check if the class extends Construct and the property is public
         const classType = parserServices.getTypeAtLocation(classDeclaration);
         const accessibility = node.accessibility ?? "public";
-        if (!isConstructType(classType) || accessibility !== "public") {
+        if (!isConstructType(classType, checker) || accessibility !== "public") {
           return;
         }
 

--- a/src/rules/require-jsdoc.ts
+++ b/src/rules/require-jsdoc.ts
@@ -5,7 +5,7 @@ import { createRule } from "../shared/create-rule";
 
 /**
  * Require JSDoc comments for interface properties and public properties in Construct classes
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const requireJSDoc = createRule({
@@ -15,6 +15,7 @@ export const requireJSDoc = createRule({
     docs: {
       description:
         "Require JSDoc comments for interface properties and public properties in Construct classes",
+      requiresTypeChecking: true,
     },
     messages: {
       missingJSDoc: "Property '{{ propertyName }}' should have a JSDoc comment.",

--- a/src/rules/require-jsdoc.ts
+++ b/src/rules/require-jsdoc.ts
@@ -1,5 +1,5 @@
-
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, ESLintUtils } from "corsa-oxlint";
+
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint } from "@typescript-eslint/utils";
 
+import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
@@ -13,8 +13,6 @@ type Option = {
 const defaultOption: Option = {
   allowNonThisAndDisallowScope: true,
 };
-
-type Context = TSESLint.RuleContext<"missingPassingThis", Option[]>;
 
 /**
  * Enforces that `this` is passed to the constructor
@@ -46,20 +44,21 @@ export const requirePassingThis = createRule({
     fixable: "code",
   },
   defaultOptions: [defaultOption],
-  create(context: Context) {
+  create(context) {
     const options = context.options[0] || defaultOption;
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type) || !node.arguments.length) return;
+        if (!isConstructType(type, checker) || !node.arguments.length) return;
 
         // NOTE: Only flag when inside a Construct/Stack class where `this` is available
         const enclosingClass = findEnclosingClass(node);
         if (!enclosingClass) return;
         const enclosingClassType = parserServices.getTypeAtLocation(enclosingClass);
-        if (!isConstructOrStackType(enclosingClassType)) return;
+        if (!isConstructOrStackType(enclosingClassType, checker)) return;
 
         const argument = node.arguments[0];
 
@@ -67,7 +66,8 @@ export const requirePassingThis = createRule({
         if (argument.type === AST_NODE_TYPES.ThisExpression) return;
 
         // NOTE: If the first argument is not `scope`, it's valid
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[0] !== "scope") return;
 
         // NOTE: If `allowNonThisAndDisallowScope` is false, require `this` for all cases

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -25,6 +25,7 @@ export const requirePassingThis = createRule({
     type: "problem",
     docs: {
       description: "Require passing `this` in a constructor.",
+      requiresTypeChecking: true,
     },
     messages: {
       missingPassingThis: "Require passing `this` in a constructor.",

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -1,5 +1,5 @@
-
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
+
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";

--- a/src/rules/require-passing-this.ts
+++ b/src/rules/require-passing-this.ts
@@ -18,7 +18,7 @@ type Context = TSESLint.RuleContext<"missingPassingThis", Option[]>;
 
 /**
  * Enforces that `this` is passed to the constructor
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const requirePassingThis = createRule({

--- a/src/rules/require-props-default-doc.ts
+++ b/src/rules/require-props-default-doc.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES, AST_TOKEN_TYPES } from "@typescript-eslint/utils";
 
+import { AST_NODE_TYPES, AST_TOKEN_TYPES } from "corsa-oxlint";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -32,7 +32,7 @@ export const requirePropsDefaultDoc = createRule({
 
         // NOTE: Check if the parent is an interface
         const parent = node.parent.parent;
-        if (parent.type !== AST_NODE_TYPES.TSInterfaceDeclaration) return;
+        if (parent?.type !== AST_NODE_TYPES.TSInterfaceDeclaration) return;
 
         // NOTE: Check if the interface name ends with 'Props'
         if (!parent.id.name.endsWith("Props")) return;

--- a/src/rules/require-props-default-doc.ts
+++ b/src/rules/require-props-default-doc.ts
@@ -1,5 +1,5 @@
-
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from "corsa-oxlint";
+
 import { createRule } from "../shared/create-rule";
 
 /**

--- a/src/rules/require-props-default-doc.ts
+++ b/src/rules/require-props-default-doc.ts
@@ -4,7 +4,7 @@ import { createRule } from "../shared/create-rule";
 
 /**
  * Requires @default JSDoc documentation for optional properties in interfaces ending with 'Props'
- * @param context - The rule context provided by ESLint
+ * @param context - The rule context
  * @returns An object containing the AST visitor functions
  */
 export const requirePropsDefaultDoc = createRule({

--- a/src/shared/create-rule.ts
+++ b/src/shared/create-rule.ts
@@ -1,5 +1,18 @@
-import { ESLintUtils } from "@typescript-eslint/utils";
+import type { Rule, RuleDefinition } from "corsa-oxlint";
 
-export const createRule = ESLintUtils.RuleCreator(
-  (name) => `https://eslint-plugin-awscdk.dev/rules/${name}`,
-);
+import { defineRule } from "corsa-oxlint";
+
+export const createRule = <MessageId extends string, const Options extends readonly unknown[]>(
+  rule: RuleDefinition<MessageId, Options> & { readonly name: string },
+): Rule => {
+  return defineRule({
+    ...rule,
+    meta: {
+      ...rule.meta,
+      docs: {
+        ...rule.meta?.docs,
+        url: `https://eslint-plugin-awscdk.dev/rules/${rule.name}`,
+      },
+    },
+  });
+};


### PR DESCRIPTION
### Issue # (if applicable)

#448

### Reason for this change

`eslint-plugin-awscdk` has so far been an ESLint-only plugin built on `@typescript-eslint/utils`. To deliver the same CDK-focused rules to oxlint users (tracked in #448), the rule layer needs to be ported off the typescript-eslint runtime onto `corsa-oxlint`, which exposes a single rule API consumable by both ESLint and oxlint.

This PR is the production-grade implementation of the POC in #422.

### Description of changes

- **Rule runtime swap**: every rule now imports `RuleContext`, `ParserServices`, `ESTree`, and friends from `corsa-oxlint` instead of `@typescript-eslint/utils`. `createRule` is rewritten on top of `defineRule` from `corsa-oxlint`, with the docs URL preserved.
- **Config layout**: `src/configs/{classic-config,flat-config}.ts` moved under `src/configs/eslint/` to make room for an oxlint config tree in a follow-up. The exported `EslintCdkPlugin` interface now references eslint's native `Linter.RulesRecord` / `Linter.Config` types.
- **Test runtime swap**: every `*.test.ts` uses `RuleTester` from `corsa-oxlint` in place of `@typescript-eslint/rule-tester`. The `@typescript-eslint/*` devDependencies are dropped.
- **No rule behavior changes intended**: rule logic, message IDs, and config presets (\`recommended\`, \`strict\`, \`classicRecommended\`, \`classicStrict\`) are preserved.

### Description of how you validated changes

- All existing unit tests pass under the new \`corsa-oxlint\` \`RuleTester\` (244/244).