### PR TITLE
refactor: rename package references from eslint-plugin-awscdk to awscdk-lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run Vite+ Checks
         run: vp check
       - name: Build docs
-        run: vp run -F @eslint-plugin-awscdk/docs build
+        run: vp run -F @awscdk-lint/docs build
       - name: Configure custom domain
         run: |
           echo "awscdk-lint.dev" > docs/.vitepress/dist/CNAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Build docs
-        run: vp run -F @eslint-plugin-awscdk/docs build
+        run: vp run -F @awscdk-lint/docs build
       - name: Configure custom domain
         run: |
           echo "awscdk-lint.dev" > docs/.vitepress/dist/CNAME

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eslint-plugin-awscdk/docs",
+  "name": "@awscdk-lint/docs",
   "private": true,
   "scripts": {
     "dev": "vitepress dev --open",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@eslint-plugin-awscdk/example-eslint",
+  "name": "@awscdk-lint/examples",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vp test --run",
     "check": "vp check",
     "pack": "vp run -r pack",
-    "docs": "vp run -F @eslint-plugin-awscdk/docs"
+    "docs": "vp run -F @awscdk-lint/docs"
   },
   "devDependencies": {
     "@voidzero-dev/vite-plus-core": "^0.1.11",

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -34,6 +34,6 @@ check_oxlint_output() {
   echo "SUCCESS: Expected error count found!"
 }
 
-check_eslint_output "vp run -F @eslint-plugin-awscdk/example-eslint eslint:esm"
-check_eslint_output "vp run -F @eslint-plugin-awscdk/example-eslint eslint:cjs"
-check_oxlint_output "vp run -F @eslint-plugin-awscdk/example-eslint oxlint"
+check_eslint_output "vp run -F @awscdk-lint/examples eslint:esm"
+check_eslint_output "vp run -F @awscdk-lint/examples eslint:cjs"
+check_oxlint_output "vp run -F @awscdk-lint/examples oxlint"


### PR DESCRIPTION

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
