### PR TITLE
fix: add support for resolving bundled tsgo executable in oxlint configuration

### DIFF
--- a/packages/oxlint/src/configs/index.ts
+++ b/packages/oxlint/src/configs/index.ts
@@ -1,13 +1,29 @@
+import { resolveBundledTsgo } from "../shared/native-preview";
+
 type RuleSeverity = "allow" | "off" | "warn" | "error" | "deny" | number;
 type RuleEntry = RuleSeverity | [RuleSeverity, ...unknown[]];
 
+type CorsaOxlintSettings = {
+  corsa?: {
+    executable?: string;
+  };
+};
+
 export type OxlintConfig = {
   jsPlugins: ["oxlint-plugin-awscdk"];
+  settings?: { corsaOxlint?: CorsaOxlintSettings };
   rules: Record<string, RuleEntry>;
 };
 
+// TODO: Drop once corsa-oxlint can resolve `@typescript/native-preview` from the calling plugin's module location.
+// https://github.com/ubugeeei-prod/corsa-bind/issues/363
+const bundledTsgo = resolveBundledTsgo();
+
 const createOxlintConfig = (rules: Record<string, RuleEntry>): OxlintConfig => ({
   jsPlugins: ["oxlint-plugin-awscdk"],
+  ...(bundledTsgo
+    ? { settings: { corsaOxlint: { corsa: { executable: bundledTsgo } } } }
+    : {}),
   rules,
 });
 

--- a/packages/oxlint/src/configs/index.ts
+++ b/packages/oxlint/src/configs/index.ts
@@ -21,9 +21,7 @@ const bundledTsgo = resolveBundledTsgo();
 
 const createOxlintConfig = (rules: Record<string, RuleEntry>): OxlintConfig => ({
   jsPlugins: ["oxlint-plugin-awscdk"],
-  ...(bundledTsgo
-    ? { settings: { corsaOxlint: { corsa: { executable: bundledTsgo } } } }
-    : {}),
+  ...(bundledTsgo ? { settings: { corsaOxlint: { corsa: { executable: bundledTsgo } } } } : {}),
   rules,
 });
 

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -1,6 +1,14 @@
 import { version } from "../package.json";
 import { configs, OxlintConfig } from "./configs";
 import { rules } from "./rules";
+import { resolveBundledTsgo } from "./shared/native-preview";
+
+// TODO: Drop once corsa-oxlint can resolve `@typescript/native-preview` from the calling plugin's module location.
+// https://github.com/ubugeeei-prod/corsa-bind/issues/363
+if (!process.env.CORSA_EXECUTABLE) {
+  const bundledTsgo = resolveBundledTsgo();
+  if (bundledTsgo) process.env.CORSA_EXECUTABLE = bundledTsgo;
+}
 
 export { configs, rules };
 

--- a/packages/oxlint/src/shared/native-preview.ts
+++ b/packages/oxlint/src/shared/native-preview.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+const localRequire = createRequire(import.meta.url);
+
+export const resolveBundledTsgo = (): string | undefined => {
+  try {
+    const packageJsonPath = localRequire.resolve("@typescript/native-preview/package.json");
+    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      bin?: string | Record<string, string>;
+    };
+    const binEntry =
+      typeof pkg.bin === "string"
+        ? pkg.bin
+        : (pkg.bin?.tsgo ?? (pkg.bin ? Object.values(pkg.bin)[0] : undefined));
+    if (!binEntry) return undefined;
+    const binPath = resolve(dirname(packageJsonPath), binEntry);
+    return existsSync(binPath) ? binPath : undefined;
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #485.

### Reason for this change

`corsa-oxlint` looks up `@typescript/native-preview` from the consumer project root only. Under pnpm's isolated layout the plugin's transitive deps are not visible there, so type-aware rules fail with `could not locate a Corsa runtime executable`.

### Description of changes

Resolve the bundled runtime from this plugin's own module location and surface it through two channels: a process-level env default for `.oxlintrc.json` (`jsPlugins`-only) consumers, and a setting on the bundled configs for `defineConfig` + `extends` consumers. User-supplied overrides keep priority. Temporary workaround tracked at https://github.com/ubugeeei-prod/corsa-bind/issues/363.

### Description of how you validated changes

- 232/232 unit tests pass.
- Manual repro under simulated pnpm isolation (root `@typescript/native-preview` symlink removed): type-aware rules execute for both `oxlint.config.ts` (extends path) and `.oxlintrc.json` (`jsPlugins`-only path).
- Manual check that an explicit `CORSA_EXECUTABLE` from the consumer is preserved.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_