### PR TITLE
fix(oxlint-plugin-awscdk): apply safe symbol lookup to remaining checker callers

### DIFF
--- a/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
@@ -110,6 +110,30 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       `,
     },
     {
+      name: "property type is Pick utility type wrapping a plain interface (regression for #492)",
+      code: `
+      interface AlarmProps {
+        readonly alarmName: string;
+        readonly threshold: number;
+      }
+      interface MyConstructProps {
+        readonly alarmProps?: Pick<AlarmProps, "alarmName">;
+      }
+      `,
+    },
+    {
+      name: "property type is Omit utility type wrapping a plain interface (regression for #492)",
+      code: `
+      interface AlarmProps {
+        readonly alarmName: string;
+        readonly threshold: number;
+      }
+      interface MyConstructProps {
+        readonly alarmProps?: Omit<AlarmProps, "alarmName">;
+      }
+      `,
+    },
+    {
       name: `property type is interface (not construct class) even if there is a class implementing it in module`,
       code: `
       class Resource {}

--- a/packages/oxlint/src/core/ts-type/checker/safe-get-symbol-of-type.ts
+++ b/packages/oxlint/src/core/ts-type/checker/safe-get-symbol-of-type.ts
@@ -4,6 +4,10 @@ import type { CorsaSymbol, CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint
  * `getSymbolOfType` throws on synthetic type arguments produced by utility types
  * like `Partial<T>` / `Record<K, V>` instead of returning undefined; swallow the
  * error so type-walking rules don't crash on those.
+ *
+ * TODO: Drop this wrapper once corsa-bind returns `undefined` instead of throwing
+ * for those handles. Tracking issue:
+ * https://github.com/ubugeeei-prod/corsa-bind/issues/364
  */
 export const safeGetSymbolOfType = (
   type: CorsaType,

--- a/packages/oxlint/src/rules/no-construct-in-interface.ts
+++ b/packages/oxlint/src/rules/no-construct-in-interface.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
+import { safeGetSymbolOfType } from "../core/ts-type/checker/safe-get-symbol-of-type";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -43,7 +44,7 @@ export const noConstructInInterface = createRule({
               messageId: "invalidInterfaceProperty",
               data: {
                 propertyName: property.key.name,
-                typeName: checker.getSymbolOfType(result)?.name ?? "",
+                typeName: safeGetSymbolOfType(result, checker)?.name ?? "",
               },
             });
           }

--- a/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -8,6 +8,7 @@ import {
 } from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
+import { safeGetSymbolOfType } from "../core/ts-type/checker/safe-get-symbol-of-type";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -53,7 +54,7 @@ const validatePublicProperty = (
   const checker = parserServices.program.getTypeChecker();
   const constructType = findTypeOfCdkConstruct(type, checker);
   if (constructType) {
-    const typeName = checker.getSymbolOfType(constructType)?.name ?? "";
+    const typeName = safeGetSymbolOfType(constructType, checker)?.name ?? "";
     context.report({
       node: publicProperty.node,
       messageId: "invalidPublicPropertyOfConstruct",

--- a/packages/oxlint/src/rules/prefer-grants-property.ts
+++ b/packages/oxlint/src/rules/prefer-grants-property.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { safeGetSymbolOfType } from "../core/ts-type/checker/safe-get-symbol-of-type";
 import { createRule } from "../shared/create-rule";
 
 export const preferGrantsProperty = createRule({
@@ -44,7 +45,7 @@ export const preferGrantsProperty = createRule({
         const grantsType = checker.getTypeOfSymbol(grantsProperty);
         if (!grantsType) return;
 
-        const grantsTypeName = checker.getSymbolOfType(grantsType)?.name;
+        const grantsTypeName = safeGetSymbolOfType(grantsType, checker)?.name;
         if (!grantsTypeName?.endsWith("Grants")) return;
 
         const convertedMethodName = methodName


### PR DESCRIPTION
### Reason for this change

`safeGetSymbolOfType`, introduced in #493 to swallow the snapshot-registry protocol error thrown by `getSymbolOfType` for synthetic type arguments, was only applied to the recursive type-walking helpers. The remaining `checker.getSymbolOfType` callers in the rule layer still call the checker directly, so the defense is not applied consistently.

### Description of changes

- Route the remaining `checker.getSymbolOfType` calls in `no-construct-in-interface`, `no-construct-in-public-property-of-construct`, and `prefer-grants-property` through `safeGetSymbolOfType`.
- Add `Pick<T, ...>` / `Omit<T, ...>` regression cases to confirm other utility types covered by the same defense do not crash the plugin.
- Note the upstream tracking issue on `safeGetSymbolOfType` so the wrapper can be removed once corsa-bind returns `undefined` instead of throwing for those handles.

### Description of how you validated changes

`vp test` passes (238 tests) and `vp check` passes.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_