### PR TITLE
fix(oxlint-plugin-awscdk): pass resolveFrom anchor to corsa-oxlint definePlugin

### DIFF
--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@typescript/native-preview": "7.0.0-dev.20260516.1",
-    "corsa-oxlint": "^0.50.0",
+    "corsa-oxlint": "^0.52.0",
     "oxlint-tsgolint": "^0.23.0"
   },
   "devDependencies": {

--- a/packages/oxlint/src/configs/index.ts
+++ b/packages/oxlint/src/configs/index.ts
@@ -15,8 +15,10 @@ export type OxlintConfig = {
   rules: Record<string, RuleEntry>;
 };
 
-// TODO: Drop once corsa-oxlint can resolve `@typescript/native-preview` from the calling plugin's module location.
-// https://github.com/ubugeeei-prod/corsa-bind/issues/363
+// Emitted alongside the CORSA_EXECUTABLE override in `../index.ts` so that
+// consumers spreading `configs.recommended`/`configs.strict` still get the
+// plugin-bundled `native-preview` even when the plugin entry has not been
+// side-effect imported (e.g. when only the config is referenced by string).
 const bundledTsgo = resolveBundledTsgo();
 
 const createOxlintConfig = (rules: Record<string, RuleEntry>): OxlintConfig => ({

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -1,10 +1,14 @@
+import { definePlugin } from "corsa-oxlint";
+
 import { version } from "../package.json";
 import { configs, OxlintConfig } from "./configs";
 import { rules } from "./rules";
 import { resolveBundledTsgo } from "./shared/native-preview";
 
-// TODO: Drop once corsa-oxlint can resolve `@typescript/native-preview` from the calling plugin's module location.
-// https://github.com/ubugeeei-prod/corsa-bind/issues/363
+// Force plugin-bundled native-preview via CORSA_EXECUTABLE. corsa-oxlint honors
+// the `resolveFrom` anchor below only as a fallback after the consumer rootDir,
+// so a consumer that happens to have an incompatible `@typescript/native-preview`
+// installed in its own node_modules would otherwise crash the plugin at runtime.
 if (!process.env.CORSA_EXECUTABLE) {
   const bundledTsgo = resolveBundledTsgo();
   if (bundledTsgo) process.env.CORSA_EXECUTABLE = bundledTsgo;
@@ -21,10 +25,16 @@ export interface OxlintCdkPlugin {
   }>;
 }
 
-const oxlintCdkPlugin: OxlintCdkPlugin = {
-  meta: { name: "awscdk", version },
+const defined = definePlugin({
+  meta: { name: "awscdk" },
+  resolveFrom: import.meta.url,
   rules,
   configs,
+});
+
+const oxlintCdkPlugin: OxlintCdkPlugin = {
+  ...(defined as unknown as OxlintCdkPlugin),
+  meta: { name: "awscdk", version },
 };
 
 export default oxlintCdkPlugin;

--- a/packages/oxlint/src/index.ts
+++ b/packages/oxlint/src/index.ts
@@ -25,16 +25,15 @@ export interface OxlintCdkPlugin {
   }>;
 }
 
-const defined = definePlugin({
-  meta: { name: "awscdk" },
-  resolveFrom: import.meta.url,
-  rules,
-  configs,
-});
-
 const oxlintCdkPlugin: OxlintCdkPlugin = {
-  ...(defined as unknown as OxlintCdkPlugin),
   meta: { name: "awscdk", version },
+  rules: definePlugin({
+    meta: { name: "awscdk" },
+    resolveFrom: import.meta.url,
+    rules,
+    configs,
+  }).rules as typeof rules,
+  configs,
 };
 
 export default oxlintCdkPlugin;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: 7.0.0-dev.20260516.1
         version: 7.0.0-dev.20260516.1
       corsa-oxlint:
-        specifier: ^0.50.0
-        version: 0.50.0(@oxlint/plugins@1.71.0)(oxlint@1.71.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)))
+        specifier: ^0.52.0
+        version: 0.52.0(@oxlint/plugins@1.71.0)(oxlint@1.71.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1)))
       oxlint-tsgolint:
         specifier: ^0.23.0
         version: 0.23.0
@@ -172,60 +172,60 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
-  '@corsa-bind/napi-darwin-arm64@0.50.0':
-    resolution: {integrity: sha512-elCxDZqzlcHlXWZB3I8CgpfUI3m7uqi4qzWXfid44QcIwjhGpBUbOqLp2TycAhK2fYt9WOoLYek4lDnQB+GEGg==}
+  '@corsa-bind/napi-darwin-arm64@0.52.0':
+    resolution: {integrity: sha512-Jqoo9FwDr+jqhk5h7E0mt/iXyX4UVkfOyjc/Sd/+BH1s57vjAwzcxO5tmvInvJM7dlmGj3cyhPP6hGvAk5eQ0g==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@corsa-bind/napi-darwin-x64@0.50.0':
-    resolution: {integrity: sha512-tsEba3dIYtgRY9OV3nKnXTGJ14UKNJYja9+GkZ6OkLrsIXcC5CuNOgZyilcPE49nqIQBs7sEbYVvoMrLFBFOgw==}
+  '@corsa-bind/napi-darwin-x64@0.52.0':
+    resolution: {integrity: sha512-goZpB5x4rjVRQl1zouxNdD0e5MCsd3CsRisMoLDjx9w9QoVfb0DC1cPmYGUgZYT3OiOZHAjA92y1/2Q2lpmoiw==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@corsa-bind/napi-linux-arm64-gnu@0.50.0':
-    resolution: {integrity: sha512-8WpGOsabV4PsRnn7umOGIqI2qtLWugqM84amk3swBG79HyTmvbdURZJrnZEJtjc9yoUuNlXbJmPEz0as44DdQw==}
+  '@corsa-bind/napi-linux-arm64-gnu@0.52.0':
+    resolution: {integrity: sha512-fIKyaJgedG2uRMKMpaj/j17xEEYP7KKBv4Y0sAGvcj0IugDOWAzS3jzerIqzulCP6y7vqN8rAhJ4JvzdJel98g==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@corsa-bind/napi-linux-arm64-musl@0.50.0':
-    resolution: {integrity: sha512-s0C7d9FSu1jz5CPocsqvF4PVNnCAEYirq09jyNW4oTST0JenqrEzZ/fSq7H7tZcJkr35Bui7tr4uJN1+sgdKJg==}
+  '@corsa-bind/napi-linux-arm64-musl@0.52.0':
+    resolution: {integrity: sha512-znVRlxbR8zGLvp3Cqx7JN36RtdEUhROVBjCxJE3lS8zndAJT8ALyrfd67bqkkbkxTu4Ycq+aOTRUcjw5ijv/OA==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@corsa-bind/napi-linux-x64-gnu@0.50.0':
-    resolution: {integrity: sha512-ohSsD9EGwHn4Tb3MXY31OkG/O79gpk75OwYXHDlvaZ0W7FSrt3wsMXv942TcJOvpquxSp+C5lelx2klixsm+XA==}
+  '@corsa-bind/napi-linux-x64-gnu@0.52.0':
+    resolution: {integrity: sha512-owzDgQ2kUBlsGO7EEcmkvxw2R/AVcUknRJCaocS4D6PDhxl0rirAd8rDjoa/PPOG7lSlp4U7AaZDfuk3iYSsnw==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@corsa-bind/napi-linux-x64-musl@0.50.0':
-    resolution: {integrity: sha512-006kIVaTJ5PF6SpIuWAyCHLHVu/iCb9yHUq1SMeOeXbE7yYq2j6w8rTB0ZU8oDOt2xGyTOID8/h7msEXcOKUrw==}
+  '@corsa-bind/napi-linux-x64-musl@0.52.0':
+    resolution: {integrity: sha512-76nTJj+8TLUk9/xG/vUDx82KbarxnRK0/FH8u/9SfRspqyOW5VLMt1YUkCw+J2dvDLPoVIWoDHh0WoQ/PbQ9FA==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@corsa-bind/napi-win32-arm64-msvc@0.50.0':
-    resolution: {integrity: sha512-lxEX213791iZSjjV73KUGky/oeKoY582AO9KWrEzZ3wqArsjAxGp/nWLGwx+BV5INC9dOLiwjHO6QiJCpEYhzQ==}
+  '@corsa-bind/napi-win32-arm64-msvc@0.52.0':
+    resolution: {integrity: sha512-LpOKIqPWHHJmeP17fnJj3r7KkfOvEOE4n7Z+8Nb2z4VYVxskM/azfvp5XnrCaa7ZpdDVz1JDmnoMx+imXvGhtg==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [win32]
 
-  '@corsa-bind/napi-win32-x64-msvc@0.50.0':
-    resolution: {integrity: sha512-THo7D1iwcd4qBc/YpYj5fk0XQMaqSsgEvFaTLxv1cpDRA9c0cQPfMMyvx9EIu9kifSSu57xQhrDnlMQ6MFQi1A==}
+  '@corsa-bind/napi-win32-x64-msvc@0.52.0':
+    resolution: {integrity: sha512-gdoe+DbhvO207uO2j9RDy8m0nas3vs2oQ3xawVG94IeTI29eKzWdVB41jfM8irmIqdGwShsx23QRhk0Ds91EKQ==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [win32]
 
-  '@corsa-bind/napi@0.50.0':
-    resolution: {integrity: sha512-YlgF/9/dIqRnZZvYmsRoH/w0xB8Pz5Fs1pgVFPPyPWQKMPJYVqNH5iGIxQC1AeHZpJpxPCUvz2fa1u5bT70DzQ==}
+  '@corsa-bind/napi@0.52.0':
+    resolution: {integrity: sha512-EgEUuWkk19K6cbjKdaBgQgIXpWTzOLI1KTTgCGcVc/5QSKlz8ZsLA8SQGs8LKIXCIPlC9zIy1J2hwMhuMPDLmA==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
 
   '@docsearch/css@4.6.3':
@@ -2125,8 +2125,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  corsa-oxlint@0.50.0:
-    resolution: {integrity: sha512-Ym4t49a9IJ064WToOBN8bbVFi3DNxbd3ZBYn97qivSNkXfkW0NQm1hOtOoO5as0yIJlKnfMpwCUlTz14JrfubQ==}
+  corsa-oxlint@0.52.0:
+    resolution: {integrity: sha512-YnSAfrwhYfGhgJui8fFhwHD3sne10gxjdoHGPSkGzKjqmk0qHa98YVeE05uewNUFkOou1nMqQl3Y/HQgVRe+Lg==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     peerDependencies:
       '@oxlint/plugins': ^1.69.0
@@ -3118,40 +3118,40 @@ snapshots:
   '@blazediff/core@1.9.1':
     optional: true
 
-  '@corsa-bind/napi-darwin-arm64@0.50.0':
+  '@corsa-bind/napi-darwin-arm64@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-darwin-x64@0.50.0':
+  '@corsa-bind/napi-darwin-x64@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-linux-arm64-gnu@0.50.0':
+  '@corsa-bind/napi-linux-arm64-gnu@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-linux-arm64-musl@0.50.0':
+  '@corsa-bind/napi-linux-arm64-musl@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-linux-x64-gnu@0.50.0':
+  '@corsa-bind/napi-linux-x64-gnu@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-linux-x64-musl@0.50.0':
+  '@corsa-bind/napi-linux-x64-musl@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-win32-arm64-msvc@0.50.0':
+  '@corsa-bind/napi-win32-arm64-msvc@0.52.0':
     optional: true
 
-  '@corsa-bind/napi-win32-x64-msvc@0.50.0':
+  '@corsa-bind/napi-win32-x64-msvc@0.52.0':
     optional: true
 
-  '@corsa-bind/napi@0.50.0':
+  '@corsa-bind/napi@0.52.0':
     optionalDependencies:
-      '@corsa-bind/napi-darwin-arm64': 0.50.0
-      '@corsa-bind/napi-darwin-x64': 0.50.0
-      '@corsa-bind/napi-linux-arm64-gnu': 0.50.0
-      '@corsa-bind/napi-linux-arm64-musl': 0.50.0
-      '@corsa-bind/napi-linux-x64-gnu': 0.50.0
-      '@corsa-bind/napi-linux-x64-musl': 0.50.0
-      '@corsa-bind/napi-win32-arm64-msvc': 0.50.0
-      '@corsa-bind/napi-win32-x64-msvc': 0.50.0
+      '@corsa-bind/napi-darwin-arm64': 0.52.0
+      '@corsa-bind/napi-darwin-x64': 0.52.0
+      '@corsa-bind/napi-linux-arm64-gnu': 0.52.0
+      '@corsa-bind/napi-linux-arm64-musl': 0.52.0
+      '@corsa-bind/napi-linux-x64-gnu': 0.52.0
+      '@corsa-bind/napi-linux-x64-musl': 0.52.0
+      '@corsa-bind/napi-win32-arm64-msvc': 0.52.0
+      '@corsa-bind/napi-win32-x64-msvc': 0.52.0
 
   '@docsearch/css@4.6.3': {}
 
@@ -4398,9 +4398,9 @@ snapshots:
   convert-source-map@2.0.0:
     optional: true
 
-  corsa-oxlint@0.50.0(@oxlint/plugins@1.71.0)(oxlint@1.71.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))):
+  corsa-oxlint@0.52.0(@oxlint/plugins@1.71.0)(oxlint@1.71.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))):
     dependencies:
-      '@corsa-bind/napi': 0.50.0
+      '@corsa-bind/napi': 0.52.0
       '@oxlint/plugins': 1.71.0
       oxlint: 1.71.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.1))(yaml@2.8.1))
 


### PR DESCRIPTION
### Reason for this change

corsa-oxlint 0.51.0 added an optional \`resolveFrom\` anchor on \`definePlugin\` that lets a plugin point corsa-oxlint at its own bundled \`@typescript/native-preview\`. Surface the anchor from this plugin.

Note: the existing \`CORSA_EXECUTABLE\` workaround intentionally stays. corsa-oxlint treats \`resolveFrom\` as a fallback after the consumer rootDir, so a consumer with an incompatible \`@typescript/native-preview\` in its own \`node_modules\` would otherwise crash the plugin at runtime.

### Description of changes

- Bump \`corsa-oxlint\` to \`^0.52.0\`.
- Thread the plugin through \`definePlugin\` with \`resolveFrom: import.meta.url\`.
- Keep the \`CORSA_EXECUTABLE\` workaround and its \`configs\` mirror; convert their comments from \`TODO\` to a note that records why they must remain.

### Description of how you validated changes

- \`vp test\` passes (238 tests) and \`vp check\` passes.
- Built a local tarball and installed it into a scratch consumer that pins \`@typescript/native-preview@7.0.0-dev.20260629.1\` in its own \`devDependencies\`. Observed the spawned tsgo child process: the plugin-bundled \`native-preview@7.0.0-dev.20260516.1\` is used and \`no-construct-in-interface\` fires correctly with no crash.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_