### PR TITLE
fix: allow default value for props in construct-constructor-property

### DIFF
--- a/packages/eslint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/eslint/src/__tests__/construct-constructor-property.test.ts
@@ -54,6 +54,43 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       `,
     },
     {
+      name: 'constructor has "scope, id, props" signature with default value props',
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps = {}) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      name: 'constructor has "scope, id" signature with default value id',
+      code: `
+      class Construct {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string = "resource") {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      name: 'constructor has "scope, id" signature with default value scope',
+      code: `
+      class Construct {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct = new Construct(), id: string) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
       name: 'constructor has more than 3 parameters but first three are "scope, id, props"',
       code: `
       class Construct {}
@@ -163,6 +200,36 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       
       export class MyConstruct extends Construct {
         constructor(scope: Construct, id: string, myProps: MyConstructProps, resourceName: string) { 
+          super(scope, id);
+        }
+      }
+      `,
+      errors: [{ messageId: "invalidConstructorProperty" }],
+    },
+    {
+      name: 'constructor has 3 parameters but third with default value is not named "props"',
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, myProps: MyConstructProps = {}) {
+          super(scope, id);
+        }
+      }
+      `,
+      errors: [{ messageId: "invalidConstructorProperty" }],
+    },
+    {
+      name: "constructor has 3 parameters but third with default value is destructured",
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        readonly bucketName?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, { bucketName }: MyConstructProps = {}) {
           super(scope, id);
         }
       }

--- a/packages/eslint/src/rules/construct-constructor-property.ts
+++ b/packages/eslint/src/rules/construct-constructor-property.ts
@@ -85,6 +85,12 @@ const checkNumOfConstructorProperty = (
 };
 
 /**
+ * Unwraps a parameter with a default value (e.g. `props: MyConstructProps = {}`) to its binding
+ */
+const unwrapDefaultValue = (param: TSESTree.Parameter): TSESTree.Parameter =>
+  param.type === AST_NODE_TYPES.AssignmentPattern ? param.left : param;
+
+/**
  * Checks if the first parameter is named "scope" and of type Construct
  */
 const checkFirstParamIsScope = (
@@ -92,12 +98,13 @@ const checkFirstParamIsScope = (
   context: Context,
   parserServices: ParserServicesWithTypeInformation,
 ) => {
-  if (firstParam.type !== AST_NODE_TYPES.Identifier || firstParam.name !== "scope") {
+  const binding = unwrapDefaultValue(firstParam);
+  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "scope") {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (!isConstructType(parserServices.getTypeAtLocation(firstParam))) {
+  } else if (!isConstructType(parserServices.getTypeAtLocation(binding))) {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorType",
@@ -109,12 +116,13 @@ const checkFirstParamIsScope = (
  * Checks if the second parameter is named "id" and of type string
  */
 const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Context) => {
-  if (secondParam.type !== AST_NODE_TYPES.Identifier || secondParam.name !== "id") {
+  const binding = unwrapDefaultValue(secondParam);
+  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "id") {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (secondParam.typeAnnotation?.typeAnnotation.type !== AST_NODE_TYPES.TSStringKeyword) {
+  } else if (binding.typeAnnotation?.typeAnnotation.type !== AST_NODE_TYPES.TSStringKeyword) {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorIdType",
@@ -127,7 +135,8 @@ const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Co
  */
 const checkThirdParamIsProps = (thirdParam: ConstructorProperties[2], context: Context) => {
   if (!thirdParam) return;
-  if (thirdParam.type !== AST_NODE_TYPES.Identifier || thirdParam.name !== "props") {
+  const binding = unwrapDefaultValue(thirdParam);
+  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "props") {
     context.report({
       node: thirdParam,
       messageId: "invalidConstructorProperty",

--- a/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
@@ -50,6 +50,40 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       interface MyConstructProps {}
 
       export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps = {}) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string = "resource") {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct = new Construct(), id: string) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
         constructor(scope: Construct, id: string, props: MyConstructProps, resourceName: string) {
           super(scope, id);
         }
@@ -145,6 +179,34 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
 
       export class MyConstruct extends Construct {
         constructor(scope: Construct, id: string, myProps: MyConstructProps, resourceName: string) {
+          super(scope, id);
+        }
+      }
+      `,
+      errors: [{ messageId: "invalidConstructorProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, myProps: MyConstructProps = {}) {
+          super(scope, id);
+        }
+      }
+      `,
+      errors: [{ messageId: "invalidConstructorProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {
+        readonly bucketName?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, { bucketName }: MyConstructProps = {}) {
           super(scope, id);
         }
       }

--- a/packages/oxlint/src/rules/construct-constructor-property.ts
+++ b/packages/oxlint/src/rules/construct-constructor-property.ts
@@ -80,6 +80,12 @@ const checkNumOfConstructorProperty = (
 };
 
 /**
+ * Unwraps a parameter with a default value (e.g. `props: MyConstructProps = {}`) to its binding
+ */
+const unwrapDefaultValue = (param: ConstructorParam) =>
+  param.type === AST_NODE_TYPES.AssignmentPattern ? param.left : param;
+
+/**
  * Checks if the first parameter is named "scope" and of type Construct
  */
 const checkFirstParamIsScope = (
@@ -87,14 +93,15 @@ const checkFirstParamIsScope = (
   context: RuleContext,
   parserServices: ParserServices,
 ) => {
-  if (firstParam.type !== AST_NODE_TYPES.Identifier || firstParam.name !== "scope") {
+  const binding = unwrapDefaultValue(firstParam);
+  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "scope") {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorProperty",
     });
   } else if (
     !isConstructType(
-      parserServices.getTypeAtLocation(firstParam),
+      parserServices.getTypeAtLocation(binding),
       parserServices.program.getTypeChecker(),
     )
   ) {
@@ -109,12 +116,13 @@ const checkFirstParamIsScope = (
  * Checks if the second parameter is named "id" and of type string
  */
 const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: RuleContext) => {
-  if (secondParam.type !== AST_NODE_TYPES.Identifier || secondParam.name !== "id") {
+  const binding = unwrapDefaultValue(secondParam);
+  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "id") {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (secondParam.typeAnnotation?.typeAnnotation.type !== AST_NODE_TYPES.TSStringKeyword) {
+  } else if (binding.typeAnnotation?.typeAnnotation.type !== AST_NODE_TYPES.TSStringKeyword) {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorIdType",
@@ -127,7 +135,8 @@ const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Ru
  */
 const checkThirdParamIsProps = (thirdParam: ConstructorProperties[2], context: RuleContext) => {
   if (!thirdParam) return;
-  if (thirdParam.type !== AST_NODE_TYPES.Identifier || thirdParam.name !== "props") {
+  const binding = unwrapDefaultValue(thirdParam);
+  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "props") {
     context.report({
       node: thirdParam,
       messageId: "invalidConstructorProperty",


### PR DESCRIPTION
### Issue # (if applicable)

Closes #509.

### Reason for this change

A constructor parameter with a default value (e.g. `props: MyConstructProps = {}`) is an `AssignmentPattern` node, not an `Identifier`, so the rule reported a false positive even though the parameter is correctly named.

### Description of changes

Unwrap `AssignmentPattern` to its inner binding before the name/type checks. Applied to all three parameters (`scope`, `id`, `props`) in both `oxlint-plugin-awscdk` and `eslint-plugin-awscdk`, since they share the same check shape.

### Description of how you validated changes

Added valid/invalid test cases for defaulted parameters to both packages (all passing). `vp check` also passes.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_